### PR TITLE
Add Severity field to tasks

### DIFF
--- a/TaskManagementSystem.Tests/IntegrationTests/Services/TasksServiceTests.cs
+++ b/TaskManagementSystem.Tests/IntegrationTests/Services/TasksServiceTests.cs
@@ -62,6 +62,7 @@ public sealed class TasksServiceTests : IClassFixture<TestDatabaseFixture>, IAsy
             Description = "Task description",
             DueDate = DateTime.UtcNow.AddDays(1),
             Priority = Priority.Low,
+            Severity = 5,
             CategoryId = _targetCategoryId
         };
 
@@ -74,6 +75,7 @@ public sealed class TasksServiceTests : IClassFixture<TestDatabaseFixture>, IAsy
         // Assert
         var expectedTask = TestResultBuilder.GetExpectedTask(resultTask.Id, taskDto);
         Assert.Equivalent(expectedTask, resultTask, strict: true);
+        Assert.Equal(taskDto.Severity, resultTask.Severity);
 
         var count = await _dbContext.Tasks.CountAsync();
         Assert.Equal(expected: 1, count);
@@ -83,6 +85,7 @@ public sealed class TasksServiceTests : IClassFixture<TestDatabaseFixture>, IAsy
 
         Assert.NotNull(savedTask);
         Assert.Equivalent(expectedTask, savedTask);
+        Assert.Equal(taskDto.Severity, savedTask!.Severity);
 
         _categoryCheckerMock.VerifyCategoryExistsCall();
     }
@@ -126,6 +129,7 @@ public sealed class TasksServiceTests : IClassFixture<TestDatabaseFixture>, IAsy
         // Assert
         var defaultPriority = Priority.Medium;
         Assert.Equal(defaultPriority, resultTask.Priority);
+        Assert.Null(resultTask.Severity);
     }
 
     #endregion

--- a/TaskManagementSystem.Tests/TestUtilities/TestResultBuilder.cs
+++ b/TaskManagementSystem.Tests/TestUtilities/TestResultBuilder.cs
@@ -9,13 +9,13 @@ namespace TaskManagementSystem.Tests.TestUtilities;
 public static class TestResultBuilder
 {
     public static TaskResponseDto GetExpectedTask(TaskEntity task)
-        => CreateBaseTaskResponse(task.Id, task.Title, task.Description, task.DueDate, task.Priority, task.IsCompleted, task.Status, task.CategoryId);
+        => CreateBaseTaskResponse(task.Id, task.Title, task.Description, task.DueDate, task.Priority, task.Severity, task.IsCompleted, task.Status, task.CategoryId);
 
     public static TaskResponseDto GetExpectedTask(int taskId, CreateTaskRequestDto task)
-        => CreateBaseTaskResponse(taskId, task.Title, task.Description, task.DueDate, task.Priority, isCompleted: false, Status.Pending, task.CategoryId);
+        => CreateBaseTaskResponse(taskId, task.Title, task.Description, task.DueDate, task.Priority, task.Severity, isCompleted: false, Status.Pending, task.CategoryId);
 
     public static TaskResponseDto GetExpectedTask(int taskId, UpdateTaskRequestDto task)
-        => CreateBaseTaskResponse(taskId, task.Title, task.Description, task.DueDate, task.Priority, isCompleted: false, task.Status, task.CategoryId);
+        => CreateBaseTaskResponse(taskId, task.Title, task.Description, task.DueDate, task.Priority, severity: null, isCompleted: false, task.Status, task.CategoryId);
 
     public static List<TaskResponseDto> GetExpectedTasks(List<TaskEntity> tasks)
     {
@@ -131,6 +131,7 @@ public static class TestResultBuilder
         string? description,
         DateTime dueDate,
         Priority? priority,
+        int? severity,
         bool isCompleted,
         Status status,
         int categoryId)
@@ -142,6 +143,7 @@ public static class TestResultBuilder
             Description = description,
             DueDate = dueDate,
             Priority = priority ?? Priority.Medium,
+            Severity = severity,
             IsCompleted = isCompleted,
             Status = status,
             CategoryId = categoryId

--- a/TaskManagementSystem.Tests/UnitTests/Controllers/TasksControllerTests.cs
+++ b/TaskManagementSystem.Tests/UnitTests/Controllers/TasksControllerTests.cs
@@ -31,6 +31,7 @@ public sealed class TasksControllerTests
             DueDate = DateTime.UtcNow.AddDays(2),
             Description = "test",
             Priority = Priority.Low,
+            Severity = 3,
             CategoryId = 1
         };
 
@@ -40,6 +41,7 @@ public sealed class TasksControllerTests
             DueDate = taskForCreate.DueDate,
             Description = taskForCreate.Description,
             Priority = taskForCreate.Priority.Value,
+            Severity = taskForCreate.Severity,
             CategoryId = taskForCreate.CategoryId
         };
 
@@ -53,6 +55,39 @@ public sealed class TasksControllerTests
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         Assert.Equal(expectedTask, okResult.Value);
 
+        _tasksServiceMock.Verify(services => services.CreateTaskAsync(taskForCreate), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateTask_WithoutSeverity_ReturnsOkResultWithNullSeverity()
+    {
+        // Arrange
+        var taskForCreate = new CreateTaskRequestDto
+        {
+            Title = "test",
+            DueDate = DateTime.UtcNow.AddDays(2),
+            Description = "test",
+            CategoryId = 1
+        };
+
+        var expectedTask = new TaskResponseDto()
+        {
+            Title = taskForCreate.Title,
+            DueDate = taskForCreate.DueDate,
+            Description = taskForCreate.Description,
+            CategoryId = taskForCreate.CategoryId,
+            Severity = null
+        };
+
+        _tasksServiceMock.Setup(service => service.CreateTaskAsync(taskForCreate))
+            .ReturnsAsync(expectedTask);
+
+        // Act
+        var result = await _tasksController.CreateTask(taskForCreate);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.Equal(expectedTask, okResult.Value);
         _tasksServiceMock.Verify(services => services.CreateTaskAsync(taskForCreate), Times.Once);
     }
 

--- a/TaskManagementSystem/DTOs/Request/CreateTaskRequestDto.cs
+++ b/TaskManagementSystem/DTOs/Request/CreateTaskRequestDto.cs
@@ -23,6 +23,8 @@ public class CreateTaskRequestDto
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public Priority? Priority { get; set; }
 
+    public int? Severity { get; set; }
+
     [Range(1, int.MaxValue)]
     public int CategoryId { get; set; }
 }

--- a/TaskManagementSystem/DTOs/Response/TaskResponseDto.cs
+++ b/TaskManagementSystem/DTOs/Response/TaskResponseDto.cs
@@ -16,6 +16,9 @@ public sealed class TaskResponseDto
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public Priority Priority { get; set; }
 
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? Severity { get; set; }
+
     public bool IsCompleted { get; set; }
 
     [JsonConverter(typeof(JsonStringEnumConverter))]

--- a/TaskManagementSystem/Database/Models/TaskEntity.cs
+++ b/TaskManagementSystem/Database/Models/TaskEntity.cs
@@ -25,6 +25,9 @@ public class TaskEntity
     [Column("priority")]
     public Priority Priority { get; set; } = Priority.Medium;
 
+    [Column("severity")]
+    public int? Severity { get; set; }
+
     [Column("is_completed")]
     public bool IsCompleted { get; set; }
 

--- a/TaskManagementSystem/Extensions/DtoMappingExtensions.cs
+++ b/TaskManagementSystem/Extensions/DtoMappingExtensions.cs
@@ -13,6 +13,7 @@ public static class DtoMappingExtensions
             Title = taskEntity.Title,
             Description = taskEntity.Description,
             Priority = taskEntity.Priority,
+            Severity = taskEntity.Severity,
             DueDate = taskEntity.DueDate,
             IsCompleted = taskEntity.IsCompleted,
             Status = taskEntity.Status,

--- a/TaskManagementSystem/Extensions/EntityMappingExtensions.cs
+++ b/TaskManagementSystem/Extensions/EntityMappingExtensions.cs
@@ -30,7 +30,8 @@ public static class EntityMappingExtensions
             DueDate = taskDto.DueDate,
             IsCompleted = false,
             Status = Status.Pending,
-            CategoryId = taskDto.CategoryId
+            CategoryId = taskDto.CategoryId,
+            Severity = taskDto.Severity
         };
 
         if (taskDto.Priority.HasValue)

--- a/TaskManagementSystem/Services/TasksService.cs
+++ b/TaskManagementSystem/Services/TasksService.cs
@@ -51,6 +51,7 @@ public sealed class TasksService : ITasksService
                 Description = x.Description,
                 DueDate = x.DueDate,
                 Priority = x.Priority,
+                Severity = x.Severity,
                 IsCompleted = x.IsCompleted,
                 Status = x.Status,
                 CategoryId = x.CategoryId


### PR DESCRIPTION
## Summary
- add nullable Severity to TaskEntity with database mapping
- expose Severity on TaskResponseDto and map through DTO conversions
- allow setting Severity via task creation and update tests accordingly

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b4218f8854833297314b8d65174b58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added optional Severity field for tasks. You can set Severity when creating tasks; it’s returned in task details and lists. If not set, it’s omitted from responses.
- Tests
  - Added integration and controller tests to verify Severity is preserved through creation and remains null when not provided.
  - Updated test utilities to build expected responses including Severity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->