### PR TITLE
Introduce task workflows via factory method

### DIFF
--- a/TaskManagementSystem.Tests/IntegrationTests/Services/TasksServiceTests.cs
+++ b/TaskManagementSystem.Tests/IntegrationTests/Services/TasksServiceTests.cs
@@ -35,7 +35,10 @@ public sealed class TasksServiceTests : IClassFixture<TestDatabaseFixture>, IAsy
         _taskDeleteOrchestrator = new Mock<ITaskDeleteOrchestrator>();
         _categoryCheckerMock = new Mock<ICategoryChecker>();
 
-        _tasksService = new TasksService(_dbContext, _categoryCheckerMock.Object, _taskDeleteOrchestrator.Object);
+        _tasksService = new ScrumTasksService(
+            _dbContext,
+            _categoryCheckerMock.Object,
+            _taskDeleteOrchestrator.Object);
     }
 
     public async Task InitializeAsync()
@@ -62,7 +65,9 @@ public sealed class TasksServiceTests : IClassFixture<TestDatabaseFixture>, IAsy
             Description = "Task description",
             DueDate = DateTime.UtcNow.AddDays(1),
             Priority = Priority.Low,
-            CategoryId = _targetCategoryId
+            CategoryId = _targetCategoryId,
+            Kind = TaskKind.Feature,
+            StoryPoints = 3
         };
 
         _categoryCheckerMock.Setup(c => c.CategoryExistsAsync(taskDto.CategoryId))
@@ -94,7 +99,9 @@ public sealed class TasksServiceTests : IClassFixture<TestDatabaseFixture>, IAsy
         var taskDto = new CreateTaskRequestDto
         {
             Title = "New Task",
-            CategoryId = 10000
+            CategoryId = 10000,
+            Kind = TaskKind.Feature,
+            StoryPoints = 3
         };
 
         _categoryCheckerMock.Setup(c => c.CategoryExistsAsync(taskDto.CategoryId))
@@ -114,7 +121,9 @@ public sealed class TasksServiceTests : IClassFixture<TestDatabaseFixture>, IAsy
         var taskDto = new CreateTaskRequestDto
         {
             Title = "New Task",
-            CategoryId = _targetCategoryId
+            CategoryId = _targetCategoryId,
+            Kind = TaskKind.Feature,
+            StoryPoints = 3
         };
 
         _categoryCheckerMock.Setup(c => c.CategoryExistsAsync(taskDto.CategoryId))
@@ -126,6 +135,29 @@ public sealed class TasksServiceTests : IClassFixture<TestDatabaseFixture>, IAsy
         // Assert
         var defaultPriority = Priority.Medium;
         Assert.Equal(defaultPriority, resultTask.Priority);
+    }
+
+    [Fact]
+    public async Task CreateTaskAsync_BugTask_DoesNotExposeStoryPoints()
+    {
+        // Arrange
+        var taskDto = new CreateTaskRequestDto
+        {
+            Title = "Bug Task",
+            CategoryId = _targetCategoryId,
+            Kind = TaskKind.Bug,
+            Severity = 5
+        };
+
+        _categoryCheckerMock.Setup(c => c.CategoryExistsAsync(taskDto.CategoryId))
+            .ReturnsAsync(true);
+
+        // Act
+        var resultTask = await _tasksService.CreateTaskAsync(taskDto);
+
+        // Assert
+        Assert.Equal(TaskKind.Bug, resultTask.Kind);
+        Assert.Null(resultTask.StoryPoints);
     }
 
     #endregion

--- a/TaskManagementSystem.Tests/TestUtilities/TestDataManager.cs
+++ b/TaskManagementSystem.Tests/TestUtilities/TestDataManager.cs
@@ -14,7 +14,7 @@ public class TestDataManager
         _dbContext = dbContext;
     }
 
-    public async Task<TaskEntity> InsertTaskAsync(string title, DateTime dueDate, Priority priority, Status status, int categoryId)
+    public async Task<TaskEntity> InsertTaskAsync(string title, DateTime dueDate, Priority priority, Status status, int categoryId, int? storyPoints = null)
     {
         var task = new TaskEntity()
         {
@@ -22,7 +22,9 @@ public class TestDataManager
             DueDate = dueDate,
             Priority = priority,
             Status = status,
-            CategoryId = categoryId
+            CategoryId = categoryId,
+            Kind = TaskKind.Feature,
+            StoryPoints = storyPoints
         };
 
         await _dbContext.AddAsync(task);
@@ -35,7 +37,8 @@ public class TestDataManager
         int count,
         int categoryId,
         Priority tasksPriority = Priority.Medium,
-        Status tasksStatus = Status.Pending)
+        Status tasksStatus = Status.Pending,
+        int? storyPoints = null)
     {
         var tasks = new List<TaskEntity>();
 
@@ -52,7 +55,9 @@ public class TestDataManager
                 Priority = tasksPriority,
                 IsCompleted = false,
                 Status = tasksStatus,
-                CategoryId = categoryId
+                CategoryId = categoryId,
+                Kind = TaskKind.Feature,
+                StoryPoints = storyPoints
             };
 
             tasks.Add(task);

--- a/TaskManagementSystem.Tests/TestUtilities/TestResultBuilder.cs
+++ b/TaskManagementSystem.Tests/TestUtilities/TestResultBuilder.cs
@@ -9,13 +9,13 @@ namespace TaskManagementSystem.Tests.TestUtilities;
 public static class TestResultBuilder
 {
     public static TaskResponseDto GetExpectedTask(TaskEntity task)
-        => CreateBaseTaskResponse(task.Id, task.Title, task.Description, task.DueDate, task.Priority, task.IsCompleted, task.Status, task.CategoryId);
+        => CreateBaseTaskResponse(task.Id, task.Title, task.Description, task.DueDate, task.Priority, task.StoryPoints, task.IsCompleted, task.Status, task.CategoryId, task.Kind);
 
     public static TaskResponseDto GetExpectedTask(int taskId, CreateTaskRequestDto task)
-        => CreateBaseTaskResponse(taskId, task.Title, task.Description, task.DueDate, task.Priority, isCompleted: false, Status.Pending, task.CategoryId);
+        => CreateBaseTaskResponse(taskId, task.Title, task.Description, task.DueDate, task.Priority, task.StoryPoints, isCompleted: false, Status.Pending, task.CategoryId, task.Kind);
 
     public static TaskResponseDto GetExpectedTask(int taskId, UpdateTaskRequestDto task)
-        => CreateBaseTaskResponse(taskId, task.Title, task.Description, task.DueDate, task.Priority, isCompleted: false, task.Status, task.CategoryId);
+        => CreateBaseTaskResponse(taskId, task.Title, task.Description, task.DueDate, task.Priority, storyPoints: null, isCompleted: false, task.Status, task.CategoryId, TaskKind.Feature);
 
     public static List<TaskResponseDto> GetExpectedTasks(List<TaskEntity> tasks)
     {
@@ -131,9 +131,11 @@ public static class TestResultBuilder
         string? description,
         DateTime dueDate,
         Priority? priority,
+        int? storyPoints,
         bool isCompleted,
         Status status,
-        int categoryId)
+        int categoryId,
+        TaskKind kind)
     {
         return new TaskResponseDto()
         {
@@ -142,9 +144,11 @@ public static class TestResultBuilder
             Description = description,
             DueDate = dueDate,
             Priority = priority ?? Priority.Medium,
+            StoryPoints = storyPoints,
             IsCompleted = isCompleted,
             Status = status,
-            CategoryId = categoryId
+            CategoryId = categoryId,
+            Kind = kind
         };
     }
 

--- a/TaskManagementSystem.Tests/UnitTests/Controllers/TasksControllerTests.cs
+++ b/TaskManagementSystem.Tests/UnitTests/Controllers/TasksControllerTests.cs
@@ -31,7 +31,9 @@ public sealed class TasksControllerTests
             DueDate = DateTime.UtcNow.AddDays(2),
             Description = "test",
             Priority = Priority.Low,
-            CategoryId = 1
+            CategoryId = 1,
+            Kind = TaskKind.Feature,
+            StoryPoints = 5
         };
 
         var expectedTask = new TaskResponseDto()
@@ -40,7 +42,9 @@ public sealed class TasksControllerTests
             DueDate = taskForCreate.DueDate,
             Description = taskForCreate.Description,
             Priority = taskForCreate.Priority.Value,
-            CategoryId = taskForCreate.CategoryId
+            CategoryId = taskForCreate.CategoryId,
+            StoryPoints = taskForCreate.StoryPoints,
+            Kind = TaskKind.Feature
         };
 
         _tasksServiceMock.Setup(service => service.CreateTaskAsync(taskForCreate))

--- a/TaskManagementSystem.Tests/UnitTests/LoggingDecorators/TasksServiceLoggingDecoratorTests.cs
+++ b/TaskManagementSystem.Tests/UnitTests/LoggingDecorators/TasksServiceLoggingDecoratorTests.cs
@@ -36,7 +36,9 @@ public sealed class TasksServiceLoggingDecoratorTests
             DueDate = DateTime.UtcNow.AddDays(2),
             Description = "test",
             Priority = Priority.Low,
-            CategoryId = 1
+            CategoryId = 1,
+            Kind = TaskKind.Feature,
+            StoryPoints = 5
         };
 
         var expectedTask = new TaskResponseDto()
@@ -45,7 +47,9 @@ public sealed class TasksServiceLoggingDecoratorTests
             DueDate = taskForCreate.DueDate,
             Description = taskForCreate.Description,
             Priority = taskForCreate.Priority.Value,
-            CategoryId = taskForCreate.CategoryId
+            CategoryId = taskForCreate.CategoryId,
+            StoryPoints = taskForCreate.StoryPoints,
+            Kind = TaskKind.Feature
         };
 
         _tasksServiceMock.Setup(service => service.CreateTaskAsync(taskForCreate))

--- a/TaskManagementSystem/DTOs/Request/CreateTaskRequestDto.cs
+++ b/TaskManagementSystem/DTOs/Request/CreateTaskRequestDto.cs
@@ -23,6 +23,13 @@ public class CreateTaskRequestDto
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public Priority? Priority { get; set; }
 
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public TaskKind Kind { get; set; } = TaskKind.Feature;
+
+    public int? Severity { get; set; }
+
+    public int? StoryPoints { get; set; }
+
     [Range(1, int.MaxValue)]
     public int CategoryId { get; set; }
 }

--- a/TaskManagementSystem/DTOs/Response/TaskResponseDto.cs
+++ b/TaskManagementSystem/DTOs/Response/TaskResponseDto.cs
@@ -16,10 +16,16 @@ public sealed class TaskResponseDto
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public Priority Priority { get; set; }
 
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? StoryPoints { get; set; }
+
     public bool IsCompleted { get; set; }
 
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public Status Status { get; set; }
 
     public int CategoryId { get; set; }
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public TaskKind Kind { get; set; } = TaskKind.Feature;
 }

--- a/TaskManagementSystem/Database/Models/TaskEntity.cs
+++ b/TaskManagementSystem/Database/Models/TaskEntity.cs
@@ -11,6 +11,9 @@ public class TaskEntity
     [Column("id")]
     public int Id { get; set; }
 
+    [Column("kind")]
+    public TaskKind Kind { get; set; } = TaskKind.Feature;
+
     [Column("title")]
     [MaxLength(EntityFiledConstants.TitleMaxLength)]
     public required string Title { get; set; }
@@ -24,6 +27,9 @@ public class TaskEntity
 
     [Column("priority")]
     public Priority Priority { get; set; } = Priority.Medium;
+
+    [Column("story_points")]
+    public int? StoryPoints { get; set; }
 
     [Column("is_completed")]
     public bool IsCompleted { get; set; }

--- a/TaskManagementSystem/Enums/TaskKind.cs
+++ b/TaskManagementSystem/Enums/TaskKind.cs
@@ -1,0 +1,9 @@
+namespace TaskManagementSystem.Enums;
+
+public enum TaskKind
+{
+    Feature,
+    Bug,
+    Incident,
+    Research
+}

--- a/TaskManagementSystem/Extensions/DependencyInjectionExtensions.cs
+++ b/TaskManagementSystem/Extensions/DependencyInjectionExtensions.cs
@@ -31,7 +31,7 @@ public static class DependencyInjectionExtensions
 
     public static IServiceCollection AddApplication(this IServiceCollection services)
     {
-        services.AddScoped<ITasksService, TasksService>();
+        services.AddScoped<ITasksService, ScrumTasksService>();
         services.Decorate<ITasksService, TasksServiceLoggingDecorator>();
 
         services.AddScoped<ICategoriesService, CategoriesSerivce>();

--- a/TaskManagementSystem/Extensions/DtoMappingExtensions.cs
+++ b/TaskManagementSystem/Extensions/DtoMappingExtensions.cs
@@ -13,10 +13,12 @@ public static class DtoMappingExtensions
             Title = taskEntity.Title,
             Description = taskEntity.Description,
             Priority = taskEntity.Priority,
+            StoryPoints = taskEntity.StoryPoints,
             DueDate = taskEntity.DueDate,
             IsCompleted = taskEntity.IsCompleted,
             Status = taskEntity.Status,
-            CategoryId = taskEntity.CategoryId
+            CategoryId = taskEntity.CategoryId,
+            Kind = taskEntity.Kind
         };
 
         return result;

--- a/TaskManagementSystem/Extensions/EntityMappingExtensions.cs
+++ b/TaskManagementSystem/Extensions/EntityMappingExtensions.cs
@@ -30,11 +30,15 @@ public static class EntityMappingExtensions
             DueDate = taskDto.DueDate,
             IsCompleted = false,
             Status = Status.Pending,
-            CategoryId = taskDto.CategoryId
+            CategoryId = taskDto.CategoryId,
+            Kind = taskDto.Kind
         };
 
         if (taskDto.Priority.HasValue)
             taskEntity.Priority = taskDto.Priority.Value;
+
+        if (taskDto.StoryPoints.HasValue)
+            taskEntity.StoryPoints = taskDto.StoryPoints.Value;
 
         return taskEntity;
     }

--- a/TaskManagementSystem/Services/ScrumTasksService.cs
+++ b/TaskManagementSystem/Services/ScrumTasksService.cs
@@ -1,0 +1,26 @@
+using TaskManagementSystem.Database;
+using TaskManagementSystem.Enums;
+using TaskManagementSystem.Interfaces;
+using TaskManagementSystem.Workflows;
+
+namespace TaskManagementSystem.Services;
+
+public sealed class ScrumTasksService : TasksServiceBase
+{
+    public ScrumTasksService(
+        TaskManagementSystemDbContext dbContext,
+        ICategoryChecker categoryChecker,
+        ITaskDeleteOrchestrator taskDeleteOrchestrator)
+        : base(dbContext, categoryChecker, taskDeleteOrchestrator)
+    {
+    }
+
+    protected override ITaskWorkflow CreateWorkflow(TaskKind kind) => kind switch
+    {
+        TaskKind.Bug => new BugWorkflow(),
+        TaskKind.Feature => new FeatureWorkflow(),
+        TaskKind.Incident => new IncidentWorkflow(),
+        TaskKind.Research => new FeatureWorkflow(),
+        _ => new FeatureWorkflow()
+    };
+}

--- a/TaskManagementSystem/Services/TasksServiceBase.cs
+++ b/TaskManagementSystem/Services/TasksServiceBase.cs
@@ -1,0 +1,144 @@
+using Microsoft.EntityFrameworkCore;
+using TaskManagementSystem.Constants;
+using TaskManagementSystem.Database;
+using TaskManagementSystem.Database.Models;
+using TaskManagementSystem.DTOs.Request;
+using TaskManagementSystem.DTOs.Response;
+using TaskManagementSystem.Enums;
+using TaskManagementSystem.Exceptions;
+using TaskManagementSystem.Extensions;
+using TaskManagementSystem.Interfaces;
+using TaskManagementSystem.Workflows;
+
+namespace TaskManagementSystem.Services;
+
+public abstract class TasksServiceBase : ITasksService
+{
+    protected abstract ITaskWorkflow CreateWorkflow(TaskKind kind);
+
+    private readonly TaskManagementSystemDbContext _dbContext;
+    private readonly ICategoryChecker _categoryChecker;
+    private readonly ITaskDeleteOrchestrator _taskDeleteOrchestrator;
+
+    protected TasksServiceBase(
+        TaskManagementSystemDbContext dbContext,
+        ICategoryChecker categoryChecker,
+        ITaskDeleteOrchestrator taskDeleteOrchestrator)
+    {
+        _dbContext = dbContext;
+        _categoryChecker = categoryChecker;
+        _taskDeleteOrchestrator = taskDeleteOrchestrator;
+    }
+
+    public async Task<TaskResponseDto> CreateTaskAsync(CreateTaskRequestDto taskDto)
+    {
+        await ValidatateCategoryAsync(taskDto.CategoryId);
+
+        var workflow = CreateWorkflow(taskDto.Kind);
+        workflow.Validate(taskDto);
+
+        var taskEntity = workflow.Build(taskDto);
+
+        await _dbContext.Tasks.AddAsync(taskEntity);
+        await _dbContext.SaveChangesAsync();
+
+        return taskEntity.ToOutDto();
+    }
+
+    public async Task<IEnumerable<TaskResponseDto>> GetAllTasksAsync(GetAllTasksRequestDto sortByInstructions)
+    {
+        var tasks = await _dbContext.Tasks
+            .SortBy(sortByInstructions)
+            .Select(x => new TaskResponseDto
+            {
+                Id = x.Id,
+                Title = x.Title,
+                Description = x.Description,
+                DueDate = x.DueDate,
+                Priority = x.Priority,
+                IsCompleted = x.IsCompleted,
+                Status = x.Status,
+                CategoryId = x.CategoryId,
+                Kind = x.Kind
+            }).ToListAsync();
+
+        return tasks;
+    }
+
+    public async Task<TaskResponseDto> GetTaskByIdAsync(int taskId)
+    {
+        var taskEntity = await _dbContext.Tasks.FindAsync(taskId)
+            ?? throw new NotFoundException(ErrorMessageConstants.TaskDoesNotExist);
+
+        return taskEntity.ToOutDto();
+    }
+
+    public async Task<TaskResponseDto> UpdateTaskAsync(int taskId, UpdateTaskRequestDto taskDto)
+    {
+        var taskEntity = await _dbContext.Tasks.FindAsync(taskId)
+            ?? throw new NotFoundException(ErrorMessageConstants.TaskDoesNotExist);
+
+        ValidateTaskStatusForUpdateAsync(taskEntity, taskDto);
+        await ValidatateCategoryAsync(taskDto.CategoryId);
+
+        taskDto.UpdateTaskEntity(taskEntity);
+
+        await _dbContext.SaveChangesAsync();
+
+        return taskEntity.ToOutDto();
+    }
+
+    public async Task UnlockTaskAsync(int taskId, UnlockTaskRequestDto unlockDto)
+    {
+        var updatedRows = await _dbContext.Tasks
+            .Where(x => x.Id == taskId && x.Status == Status.Locked)
+            .ExecuteUpdateAsync(x => x.SetProperty(x => x.Status, unlockDto.Status));
+
+        if (updatedRows is 0)
+            throw new NotFoundException(ErrorMessageConstants.LockedTaskWithIdDoesNotExist);
+    }
+
+    public async Task<DeleteAction> DeleteTaskAsync(int taskId)
+    {
+        var taskEntity = await _dbContext.Tasks.FindAsync(taskId)
+            ?? throw new NotFoundException(ErrorMessageConstants.TaskDoesNotExist);
+
+        ValidateTaskStatusForDeletion(taskEntity);
+
+        var deleteAction = await _taskDeleteOrchestrator.ExecuteDeletionAsync(taskEntity, _dbContext);
+
+        return deleteAction;
+    }
+
+    private async Task ValidatateCategoryAsync(int categoryId)
+    {
+        var categoryExists = await _categoryChecker.CategoryExistsAsync(categoryId);
+
+        if (!categoryExists)
+            throw new BadHttpRequestException(ErrorMessageConstants.CategoryDoesNotExist);
+    }
+
+    private static void ValidateTaskStatusForDeletion(TaskEntity taskEntity)
+    {
+        if (taskEntity.Status == Status.Locked)
+            throw new ConflictException(ErrorMessageConstants.TaskAlreadyLocked);
+
+        if (taskEntity.Status == Status.Archived)
+            throw new ConflictException(ErrorMessageConstants.ArchivedTaskCanNotBeDeleted);
+    }
+
+    private void ValidateTaskStatusForUpdateAsync(TaskEntity taskEntity, UpdateTaskRequestDto taskDto)
+    {
+        var canArchivedBeEdited = taskEntity.Status == Status.Archived;
+        if (canArchivedBeEdited)
+            throw new ConflictException(ErrorMessageConstants.ArchivedTaskCanNotBeEdited);
+
+        var canArchiveEntity = taskEntity.Status != Status.Completed && taskDto.Status == Status.Archived;
+        if (canArchiveEntity)
+            throw new ConflictException(ErrorMessageConstants.OnlyCompletedTaskCanBeArchived);
+
+        var canLockedBeEdited = taskEntity.Status == Status.Locked;
+        if (canLockedBeEdited)
+            throw new ConflictException(ErrorMessageConstants.LockedTaskCanNotBeEdited);
+    }
+}

--- a/TaskManagementSystem/Workflows/BugWorkflow.cs
+++ b/TaskManagementSystem/Workflows/BugWorkflow.cs
@@ -1,0 +1,32 @@
+using TaskManagementSystem.DTOs.Request;
+using TaskManagementSystem.Database.Models;
+using TaskManagementSystem.Enums;
+
+namespace TaskManagementSystem.Workflows;
+
+public sealed class BugWorkflow : ITaskWorkflow
+{
+    public void Validate(CreateTaskRequestDto dto)
+    {
+        if (!dto.Severity.HasValue)
+            throw new ArgumentException("Bug requires Severity.");
+    }
+
+    public TaskEntity Build(CreateTaskRequestDto dto)
+    {
+        var priority = dto.Severity >= 4 ? Priority.High : Priority.Low;
+        var dueDate = dto.DueDate != default ? dto.DueDate : DateTime.UtcNow.AddDays(2);
+
+        return new TaskEntity
+        {
+            Title = dto.Title,
+            Description = dto.Description,
+            DueDate = dueDate,
+            Priority = priority,
+            IsCompleted = false,
+            Status = Status.Pending,
+            CategoryId = dto.CategoryId,
+            Kind = TaskKind.Bug
+        };
+    }
+}

--- a/TaskManagementSystem/Workflows/FeatureWorkflow.cs
+++ b/TaskManagementSystem/Workflows/FeatureWorkflow.cs
@@ -1,0 +1,33 @@
+using TaskManagementSystem.DTOs.Request;
+using TaskManagementSystem.Database.Models;
+using TaskManagementSystem.Enums;
+
+namespace TaskManagementSystem.Workflows;
+
+public sealed class FeatureWorkflow : ITaskWorkflow
+{
+    public void Validate(CreateTaskRequestDto dto)
+    {
+        if (!dto.StoryPoints.HasValue)
+            throw new ArgumentException("Feature requires StoryPoints.");
+    }
+
+    public TaskEntity Build(CreateTaskRequestDto dto)
+    {
+        var dueDate = dto.DueDate != default ? dto.DueDate : DateTime.UtcNow.AddDays(14);
+        var priority = dto.Priority ?? Priority.Medium;
+
+        return new TaskEntity
+        {
+            Title = dto.Title,
+            Description = dto.Description,
+            DueDate = dueDate,
+            Priority = priority,
+            StoryPoints = dto.StoryPoints,
+            IsCompleted = false,
+            Status = Status.Pending,
+            CategoryId = dto.CategoryId,
+            Kind = TaskKind.Feature
+        };
+    }
+}

--- a/TaskManagementSystem/Workflows/ITaskWorkflow.cs
+++ b/TaskManagementSystem/Workflows/ITaskWorkflow.cs
@@ -1,0 +1,10 @@
+using TaskManagementSystem.DTOs.Request;
+using TaskManagementSystem.Database.Models;
+
+namespace TaskManagementSystem.Workflows;
+
+public interface ITaskWorkflow
+{
+    void Validate(CreateTaskRequestDto dto);
+    TaskEntity Build(CreateTaskRequestDto dto);
+}

--- a/TaskManagementSystem/Workflows/IncidentWorkflow.cs
+++ b/TaskManagementSystem/Workflows/IncidentWorkflow.cs
@@ -1,0 +1,27 @@
+using TaskManagementSystem.DTOs.Request;
+using TaskManagementSystem.Database.Models;
+using TaskManagementSystem.Enums;
+
+namespace TaskManagementSystem.Workflows;
+
+public sealed class IncidentWorkflow : ITaskWorkflow
+{
+    public void Validate(CreateTaskRequestDto dto) { }
+
+    public TaskEntity Build(CreateTaskRequestDto dto)
+    {
+        var dueDate = dto.DueDate != default ? dto.DueDate : DateTime.UtcNow.AddHours(4);
+
+        return new TaskEntity
+        {
+            Title = dto.Title,
+            Description = dto.Description,
+            DueDate = dueDate,
+            Priority = Priority.High,
+            IsCompleted = false,
+            Status = Status.InProgress,
+            CategoryId = dto.CategoryId,
+            Kind = TaskKind.Incident
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add TaskKind domain concept with specialized workflows for Bug, Feature and Incident
- refactor task creation into TasksServiceBase using factory method
- remove notification bus from workflows and services
- add nullable StoryPoints field for feature tasks and update tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b31694e3a48332a63cab2d8fec8986