### PR TITLE
Add backlog ordering abstract factory

### DIFF
--- a/TaskManagementSystem.Tests/UnitTests/Controllers/TasksControllerTests.cs
+++ b/TaskManagementSystem.Tests/UnitTests/Controllers/TasksControllerTests.cs
@@ -95,6 +95,34 @@ public sealed class TasksControllerTests
 
     #endregion
 
+    #region GetBacklog
+
+    [Fact]
+    public async Task GetBacklog_TaskKindProvided_ReturnsOkResultWithOrderedBacklog()
+    {
+        // Arrange
+        var kind = TaskKind.Feature;
+        var expectedResponse = new List<TaskResponseDto>()
+        {
+            new TaskResponseDto() { Title = "1" },
+            new TaskResponseDto() { Title = "2" }
+        };
+
+        _tasksServiceMock.Setup(service => service.GetBacklogAsync(kind))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _tasksController.GetBacklog(kind);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.Equal(expectedResponse, okResult.Value);
+
+        _tasksServiceMock.Verify(services => services.GetBacklogAsync(kind), Times.Once);
+    }
+
+    #endregion
+
     #region GetTaskById
 
     [Fact]

--- a/TaskManagementSystem.Tests/UnitTests/LoggingDecorators/TasksServiceLoggingDecoratorTests.cs
+++ b/TaskManagementSystem.Tests/UnitTests/LoggingDecorators/TasksServiceLoggingDecoratorTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
 using Moq;
 using TaskManagementSystem.Constants;
 using TaskManagementSystem.DTOs.Request;
@@ -97,6 +98,32 @@ public sealed class TasksServiceLoggingDecoratorTests
         Assert.Equal(expectedResponse, result);
 
         _tasksServiceMock.Verify(services => services.GetAllTasksAsync(sortByInstructions), Times.Once);
+    }
+
+    #endregion
+
+    #region GetBacklog
+
+    [Fact]
+    public async Task GetBacklogAsync_TaskKindProvided_DelegatesToInnerService()
+    {
+        // Arrange
+        var kind = TaskKind.Feature;
+        var expectedResponse = new List<TaskResponseDto>()
+        {
+            new TaskResponseDto() { Title = "1" },
+            new TaskResponseDto() { Title = "2" }
+        };
+
+        _tasksServiceMock.Setup(service => service.GetBacklogAsync(kind))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _tasksServiceLoggingDecorator.GetBacklogAsync(kind);
+
+        // Assert
+        Assert.Equal(expectedResponse, result);
+        _tasksServiceMock.Verify(services => services.GetBacklogAsync(kind), Times.Once);
     }
 
     #endregion

--- a/TaskManagementSystem/BacklogOrderings/BugBacklogOrdering.cs
+++ b/TaskManagementSystem/BacklogOrderings/BugBacklogOrdering.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Linq;
+using TaskManagementSystem.DTOs.Response;
+using TaskManagementSystem.Interfaces;
+
+namespace TaskManagementSystem.BacklogOrderings;
+
+public sealed class BugBacklogOrdering : IBacklogOrdering
+{
+    public IEnumerable<TaskResponseDto> Order(IEnumerable<TaskResponseDto> backlog)
+    {
+        return backlog
+            .OrderByDescending(task => task.Priority)
+            .ThenBy(task => task.DueDate)
+            .ThenBy(task => task.Id)
+            .ToList();
+    }
+}

--- a/TaskManagementSystem/BacklogOrderings/DefaultBacklogOrdering.cs
+++ b/TaskManagementSystem/BacklogOrderings/DefaultBacklogOrdering.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Linq;
+using TaskManagementSystem.DTOs.Response;
+using TaskManagementSystem.Interfaces;
+
+namespace TaskManagementSystem.BacklogOrderings;
+
+public sealed class DefaultBacklogOrdering : IBacklogOrdering
+{
+    public IEnumerable<TaskResponseDto> Order(IEnumerable<TaskResponseDto> backlog)
+    {
+        return backlog
+            .OrderBy(task => task.DueDate)
+            .ThenBy(task => task.Id)
+            .ToList();
+    }
+}

--- a/TaskManagementSystem/BacklogOrderings/FeatureBacklogOrdering.cs
+++ b/TaskManagementSystem/BacklogOrderings/FeatureBacklogOrdering.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Linq;
+using TaskManagementSystem.DTOs.Response;
+using TaskManagementSystem.Interfaces;
+
+namespace TaskManagementSystem.BacklogOrderings;
+
+public sealed class FeatureBacklogOrdering : IBacklogOrdering
+{
+    public IEnumerable<TaskResponseDto> Order(IEnumerable<TaskResponseDto> backlog)
+    {
+        return backlog
+            .OrderBy(task => task.StoryPoints ?? int.MaxValue)
+            .ThenBy(task => task.DueDate)
+            .ThenByDescending(task => task.Priority)
+            .ThenBy(task => task.Id)
+            .ToList();
+    }
+}

--- a/TaskManagementSystem/BacklogOrderings/IncidentBacklogOrdering.cs
+++ b/TaskManagementSystem/BacklogOrderings/IncidentBacklogOrdering.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Linq;
+using TaskManagementSystem.DTOs.Response;
+using TaskManagementSystem.Interfaces;
+
+namespace TaskManagementSystem.BacklogOrderings;
+
+public sealed class IncidentBacklogOrdering : IBacklogOrdering
+{
+    public IEnumerable<TaskResponseDto> Order(IEnumerable<TaskResponseDto> backlog)
+    {
+        return backlog
+            .OrderBy(task => task.DueDate)
+            .ThenByDescending(task => task.Priority)
+            .ThenBy(task => task.Id)
+            .ToList();
+    }
+}

--- a/TaskManagementSystem/Constants/RouteConstants.cs
+++ b/TaskManagementSystem/Constants/RouteConstants.cs
@@ -14,4 +14,5 @@ public class RouteConstants
 
     public const string Tasks = $"{Api}/tasks";
     public const string TaskById = $"{Api}/tasks/{IdParamName}";
+    public const string TaskBacklog = $"{Api}/tasks/backlog";
 }

--- a/TaskManagementSystem/Controllers/TasksController.cs
+++ b/TaskManagementSystem/Controllers/TasksController.cs
@@ -35,6 +35,15 @@ public class TasksController : ControllerBase
     }
 
     [HttpGet]
+    [Route(RouteConstants.TaskBacklog)]
+    public async Task<ActionResult<IEnumerable<TaskResponseDto>>> GetBacklog([FromQuery] TaskKind kind)
+    {
+        var result = await _tasksService.GetBacklogAsync(kind);
+
+        return Ok(result);
+    }
+
+    [HttpGet]
     [Route(RouteConstants.TaskById)]
     public async Task<ActionResult<TaskResponseDto>> GetTaskById([FromRoute] int id)
     {

--- a/TaskManagementSystem/Extensions/DependencyInjectionExtensions.cs
+++ b/TaskManagementSystem/Extensions/DependencyInjectionExtensions.cs
@@ -7,6 +7,7 @@ using TaskManagementSystem.Interfaces;
 using TaskManagementSystem.LoggingDecorators;
 using TaskManagementSystem.Checkers;
 using TaskManagementSystem.Services;
+using TaskManagementSystem.Factories;
 
 namespace TaskManagementSystem.Extensions;
 
@@ -33,6 +34,8 @@ public static class DependencyInjectionExtensions
     {
         services.AddScoped<ITasksService, ScrumTasksService>();
         services.Decorate<ITasksService, TasksServiceLoggingDecorator>();
+
+        services.AddScoped<ITaskArtifactsFactory, ScrumTaskArtifactsFactory>();
 
         services.AddScoped<ICategoriesService, CategoriesSerivce>();
         services.Decorate<ICategoriesService, CategoriesServiceLoggingDecorator>();

--- a/TaskManagementSystem/Factories/ScrumTaskArtifactsFactory.cs
+++ b/TaskManagementSystem/Factories/ScrumTaskArtifactsFactory.cs
@@ -1,0 +1,27 @@
+using TaskManagementSystem.BacklogOrderings;
+using TaskManagementSystem.Enums;
+using TaskManagementSystem.Interfaces;
+using TaskManagementSystem.Workflows;
+
+namespace TaskManagementSystem.Factories;
+
+public sealed class ScrumTaskArtifactsFactory : ITaskArtifactsFactory
+{
+    public ITaskWorkflow CreateWorkflow(TaskKind kind) => kind switch
+    {
+        TaskKind.Bug => new BugWorkflow(),
+        TaskKind.Feature => new FeatureWorkflow(),
+        TaskKind.Incident => new IncidentWorkflow(),
+        TaskKind.Research => new FeatureWorkflow(),
+        _ => new FeatureWorkflow()
+    };
+
+    public IBacklogOrdering CreateBacklogOrdering(TaskKind kind) => kind switch
+    {
+        TaskKind.Bug => new BugBacklogOrdering(),
+        TaskKind.Feature => new FeatureBacklogOrdering(),
+        TaskKind.Incident => new IncidentBacklogOrdering(),
+        TaskKind.Research => new FeatureBacklogOrdering(),
+        _ => new DefaultBacklogOrdering()
+    };
+}

--- a/TaskManagementSystem/Interfaces/Factories/ITaskArtifactsFactory.cs
+++ b/TaskManagementSystem/Interfaces/Factories/ITaskArtifactsFactory.cs
@@ -1,0 +1,11 @@
+using TaskManagementSystem.Enums;
+using TaskManagementSystem.Workflows;
+
+namespace TaskManagementSystem.Interfaces;
+
+public interface ITaskArtifactsFactory
+{
+    ITaskWorkflow CreateWorkflow(TaskKind kind);
+
+    IBacklogOrdering CreateBacklogOrdering(TaskKind kind);
+}

--- a/TaskManagementSystem/Interfaces/IBacklogOrdering.cs
+++ b/TaskManagementSystem/Interfaces/IBacklogOrdering.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+using TaskManagementSystem.DTOs.Response;
+
+namespace TaskManagementSystem.Interfaces;
+
+public interface IBacklogOrdering
+{
+    IEnumerable<TaskResponseDto> Order(IEnumerable<TaskResponseDto> backlog);
+}

--- a/TaskManagementSystem/Interfaces/Services/ITasksService.cs
+++ b/TaskManagementSystem/Interfaces/Services/ITasksService.cs
@@ -10,6 +10,8 @@ public interface ITasksService
 
     Task<IEnumerable<TaskResponseDto>> GetAllTasksAsync(GetAllTasksRequestDto sortBy);
 
+    Task<IEnumerable<TaskResponseDto>> GetBacklogAsync(TaskKind kind);
+
     Task<TaskResponseDto> GetTaskByIdAsync(int taskId);
 
     Task<TaskResponseDto> UpdateTaskAsync(int taskId, UpdateTaskRequestDto taskDto);

--- a/TaskManagementSystem/LoggingDecorators/TasksServiceLoggingDecorator.cs
+++ b/TaskManagementSystem/LoggingDecorators/TasksServiceLoggingDecorator.cs
@@ -33,6 +33,11 @@ public class TasksServiceLoggingDecorator : ITasksService
         return await _wrappee.GetAllTasksAsync(sortBy);
     }
 
+    public async Task<IEnumerable<TaskResponseDto>> GetBacklogAsync(TaskKind kind)
+    {
+        return await _wrappee.GetBacklogAsync(kind);
+    }
+
     public async Task<TaskResponseDto> GetTaskByIdAsync(int taskId)
     {
         return await _wrappee.GetTaskByIdAsync(taskId);

--- a/TaskManagementSystem/Services/ScrumTasksService.cs
+++ b/TaskManagementSystem/Services/ScrumTasksService.cs
@@ -1,7 +1,5 @@
 using TaskManagementSystem.Database;
-using TaskManagementSystem.Enums;
 using TaskManagementSystem.Interfaces;
-using TaskManagementSystem.Workflows;
 
 namespace TaskManagementSystem.Services;
 
@@ -10,17 +8,9 @@ public sealed class ScrumTasksService : TasksServiceBase
     public ScrumTasksService(
         TaskManagementSystemDbContext dbContext,
         ICategoryChecker categoryChecker,
-        ITaskDeleteOrchestrator taskDeleteOrchestrator)
-        : base(dbContext, categoryChecker, taskDeleteOrchestrator)
+        ITaskDeleteOrchestrator taskDeleteOrchestrator,
+        ITaskArtifactsFactory taskArtifactsFactory)
+        : base(dbContext, categoryChecker, taskDeleteOrchestrator, taskArtifactsFactory)
     {
     }
-
-    protected override ITaskWorkflow CreateWorkflow(TaskKind kind) => kind switch
-    {
-        TaskKind.Bug => new BugWorkflow(),
-        TaskKind.Feature => new FeatureWorkflow(),
-        TaskKind.Incident => new IncidentWorkflow(),
-        TaskKind.Research => new FeatureWorkflow(),
-        _ => new FeatureWorkflow()
-    };
 }

--- a/TaskManagementSystem/Services/TasksService.cs
+++ b/TaskManagementSystem/Services/TasksService.cs
@@ -1,14 +1,16 @@
-﻿using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using TaskManagementSystem.BacklogOrderings;
 using TaskManagementSystem.Constants;
-using TaskManagementSystem.Database.Models;
 using TaskManagementSystem.Database;
+using TaskManagementSystem.Database.Models;
 using TaskManagementSystem.DTOs.Request;
 using TaskManagementSystem.DTOs.Response;
+using TaskManagementSystem.Enums;
 using TaskManagementSystem.Exceptions;
+using TaskManagementSystem.Extensions;
 using TaskManagementSystem.Helpers;
 using TaskManagementSystem.Interfaces;
-using TaskManagementSystem.Enums;
-using TaskManagementSystem.Extensions;
 
 namespace TaskManagementSystem.Services;
 
@@ -17,13 +19,13 @@ public sealed class TasksService : ITasksService
     private readonly TaskManagementSystemDbContext _dbContext;
     private readonly ICategoryChecker _categoryChecker;
     private readonly ITaskDeleteOrchestrator _taskDeleteOrchestrator;
-    
+
     public TasksService(
         TaskManagementSystemDbContext dbContext,
         ICategoryChecker categoryChecker,
         ITaskDeleteOrchestrator taskDeleteOrchestrator)
     {
-        _dbContext = dbContext; 
+        _dbContext = dbContext;
         _categoryChecker = categoryChecker;
         _taskDeleteOrchestrator = taskDeleteOrchestrator;
     }
@@ -51,12 +53,43 @@ public sealed class TasksService : ITasksService
                 Description = x.Description,
                 DueDate = x.DueDate,
                 Priority = x.Priority,
+                StoryPoints = x.StoryPoints,
                 IsCompleted = x.IsCompleted,
                 Status = x.Status,
-                CategoryId = x.CategoryId
+                CategoryId = x.CategoryId,
+                Kind = x.Kind
             }).ToListAsync();
 
         return tasks;
+    }
+
+    public async Task<IEnumerable<TaskResponseDto>> GetBacklogAsync(TaskKind kind)
+    {
+        var backlogOrdering = new DefaultBacklogOrdering();
+
+        var backlog = await _dbContext.Tasks
+            .Where(task =>
+                task.Kind == kind &&
+                task.Status != Status.Completed &&
+                task.Status != Status.Archived)
+            .Select(x => new TaskResponseDto
+            {
+                Id = x.Id,
+                Title = x.Title,
+                Description = x.Description,
+                DueDate = x.DueDate,
+                Priority = x.Priority,
+                StoryPoints = x.StoryPoints,
+                IsCompleted = x.IsCompleted,
+                Status = x.Status,
+                CategoryId = x.CategoryId,
+                Kind = x.Kind
+            })
+            .ToListAsync();
+
+        var orderedBacklog = backlogOrdering.Order(backlog).ToList();
+
+        return orderedBacklog;
     }
 
     public async Task<TaskResponseDto> GetTaskByIdAsync(int taskId)
@@ -87,7 +120,7 @@ public sealed class TasksService : ITasksService
         var updatedRows = await _dbContext.Tasks
             .Where(x => x.Id == taskId && x.Status == Status.Locked)
             .ExecuteUpdateAsync(x => x.SetProperty(x => x.Status, unlockDto.Status));
-	
+
         if (updatedRows is 0)
             throw new NotFoundException(ErrorMessageConstants.LockedTaskWithIdDoesNotExist);
     }


### PR DESCRIPTION
## Summary
- introduce backlog ordering strategies and an abstract factory that pairs workflows with orderings
- update Scrum task services and controller to surface backlog retrieval using the pluggable ordering
- expand dependency injection and test suites for the new backlog capability

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cfca06b8b083328b8bc5a94470b029

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added GET /api/tasks/backlog endpoint to fetch backlog items by task kind (query: kind).
  - Backlog lists are now automatically ordered per kind for clearer prioritization (e.g., by priority, due date, story points).
  - Task responses now include StoryPoints and Kind fields across relevant endpoints.

- Tests
  - Added unit and integration tests covering backlog retrieval, ordering, and controller behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->