### PR TITLE
Add TaskEntity builder and workflow coverage

### DIFF
--- a/TaskManagementSystem.Tests/UnitTests/Builders/TaskEntityBuilderTests.cs
+++ b/TaskManagementSystem.Tests/UnitTests/Builders/TaskEntityBuilderTests.cs
@@ -1,0 +1,67 @@
+using TaskManagementSystem.Builders;
+using TaskManagementSystem.Enums;
+using Xunit;
+
+namespace TaskManagementSystem.Tests.UnitTests.Builders;
+
+public sealed class TaskEntityBuilderTests
+{
+    [Fact]
+    public void Build_WithDefaultInitialization_SetsSharedFields()
+    {
+        // Arrange
+        var dueDate = DateTime.UtcNow.AddDays(1);
+
+        // Act
+        var task = TaskEntityBuilder.Create("Title", "Description", dueDate, 5, TaskKind.Feature)
+            .Build();
+
+        // Assert
+        Assert.Equal("Title", task.Title);
+        Assert.Equal("Description", task.Description);
+        Assert.Equal(dueDate, task.DueDate);
+        Assert.Equal(5, task.CategoryId);
+        Assert.Equal(TaskKind.Feature, task.Kind);
+        Assert.Equal(Priority.Medium, task.Priority);
+        Assert.Equal(Status.Pending, task.Status);
+        Assert.False(task.IsCompleted);
+        Assert.Null(task.StoryPoints);
+    }
+
+    [Fact]
+    public void WithPriority_WhenCalled_OverridesPriority()
+    {
+        // Act
+        var task = TaskEntityBuilder.Create("Title", null, DateTime.UtcNow, 1, TaskKind.Bug)
+            .WithPriority(Priority.High)
+            .Build();
+
+        // Assert
+        Assert.Equal(Priority.High, task.Priority);
+    }
+
+    [Fact]
+    public void WithStatus_WhenCompleted_SetsCompletionFlag()
+    {
+        // Act
+        var task = TaskEntityBuilder.Create("Title", null, DateTime.UtcNow, 1, TaskKind.Feature)
+            .WithStatus(Status.Completed)
+            .Build();
+
+        // Assert
+        Assert.Equal(Status.Completed, task.Status);
+        Assert.True(task.IsCompleted);
+    }
+
+    [Fact]
+    public void WithStoryPoints_WhenProvided_SetsStoryPoints()
+    {
+        // Act
+        var task = TaskEntityBuilder.Create("Title", null, DateTime.UtcNow, 1, TaskKind.Feature)
+            .WithStoryPoints(8)
+            .Build();
+
+        // Assert
+        Assert.Equal(8, task.StoryPoints);
+    }
+}

--- a/TaskManagementSystem.Tests/UnitTests/Workflows/BugWorkflowTests.cs
+++ b/TaskManagementSystem.Tests/UnitTests/Workflows/BugWorkflowTests.cs
@@ -1,0 +1,81 @@
+using TaskManagementSystem.DTOs.Request;
+using TaskManagementSystem.Enums;
+using TaskManagementSystem.Workflows;
+using Xunit;
+
+namespace TaskManagementSystem.Tests.UnitTests.Workflows;
+
+public sealed class BugWorkflowTests
+{
+    private readonly BugWorkflow _workflow = new();
+
+    [Fact]
+    public void Build_WithHighSeverity_UsesHighPriorityAndDefaultDueDate()
+    {
+        // Arrange
+        var dto = new CreateTaskRequestDto
+        {
+            Title = "Critical bug",
+            Description = "Fix immediately",
+            DueDate = default,
+            CategoryId = 7,
+            Kind = TaskKind.Bug,
+            Severity = 5
+        };
+
+        var before = DateTime.UtcNow;
+
+        // Act
+        var task = _workflow.Build(dto);
+
+        var after = DateTime.UtcNow;
+
+        // Assert
+        Assert.Equal(Priority.High, task.Priority);
+        Assert.Equal(TaskKind.Bug, task.Kind);
+        Assert.Equal(dto.Title, task.Title);
+        Assert.Equal(dto.Description, task.Description);
+        Assert.Equal(dto.CategoryId, task.CategoryId);
+        Assert.Equal(Status.Pending, task.Status);
+        Assert.False(task.IsCompleted);
+        Assert.InRange(task.DueDate, before.AddDays(2), after.AddDays(2));
+    }
+
+    [Fact]
+    public void Build_WithLowSeverity_UsesProvidedDueDateAndLowPriority()
+    {
+        // Arrange
+        var dueDate = DateTime.UtcNow.AddDays(5);
+        var dto = new CreateTaskRequestDto
+        {
+            Title = "Minor bug",
+            DueDate = dueDate,
+            CategoryId = 2,
+            Kind = TaskKind.Bug,
+            Severity = 2
+        };
+
+        // Act
+        var task = _workflow.Build(dto);
+
+        // Assert
+        Assert.Equal(Priority.Low, task.Priority);
+        Assert.Equal(dueDate, task.DueDate);
+    }
+
+    [Fact]
+    public void Validate_WithoutSeverity_ThrowsArgumentException()
+    {
+        // Arrange
+        var dto = new CreateTaskRequestDto
+        {
+            Title = "Bug",
+            DueDate = DateTime.UtcNow.AddDays(1),
+            CategoryId = 1,
+            Kind = TaskKind.Bug
+        };
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => _workflow.Validate(dto));
+    }
+}

--- a/TaskManagementSystem.Tests/UnitTests/Workflows/FeatureWorkflowTests.cs
+++ b/TaskManagementSystem.Tests/UnitTests/Workflows/FeatureWorkflowTests.cs
@@ -1,0 +1,78 @@
+using TaskManagementSystem.DTOs.Request;
+using TaskManagementSystem.Enums;
+using TaskManagementSystem.Workflows;
+using Xunit;
+
+namespace TaskManagementSystem.Tests.UnitTests.Workflows;
+
+public sealed class FeatureWorkflowTests
+{
+    private readonly FeatureWorkflow _workflow = new();
+
+    [Fact]
+    public void Build_WhenPriorityProvided_UsesPriorityAndDefaultDueDate()
+    {
+        // Arrange
+        var dto = new CreateTaskRequestDto
+        {
+            Title = "Feature",
+            Description = "New capability",
+            DueDate = default,
+            Priority = Priority.High,
+            StoryPoints = 3,
+            CategoryId = 9,
+            Kind = TaskKind.Feature
+        };
+
+        var before = DateTime.UtcNow;
+
+        // Act
+        var task = _workflow.Build(dto);
+
+        var after = DateTime.UtcNow;
+
+        // Assert
+        Assert.Equal(Priority.High, task.Priority);
+        Assert.Equal(TaskKind.Feature, task.Kind);
+        Assert.Equal(3, task.StoryPoints);
+        Assert.InRange(task.DueDate, before.AddDays(14), after.AddDays(14));
+    }
+
+    [Fact]
+    public void Validate_WithoutStoryPoints_ThrowsArgumentException()
+    {
+        // Arrange
+        var dto = new CreateTaskRequestDto
+        {
+            Title = "Feature",
+            DueDate = DateTime.UtcNow.AddDays(1),
+            CategoryId = 3,
+            Kind = TaskKind.Feature
+        };
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => _workflow.Validate(dto));
+    }
+
+    [Fact]
+    public void Build_WhenPriorityNotProvided_UsesMediumPriority()
+    {
+        // Arrange
+        var dueDate = DateTime.UtcNow.AddDays(3);
+        var dto = new CreateTaskRequestDto
+        {
+            Title = "Feature",
+            DueDate = dueDate,
+            StoryPoints = 5,
+            CategoryId = 4,
+            Kind = TaskKind.Feature
+        };
+
+        // Act
+        var task = _workflow.Build(dto);
+
+        // Assert
+        Assert.Equal(Priority.Medium, task.Priority);
+        Assert.Equal(dueDate, task.DueDate);
+    }
+}

--- a/TaskManagementSystem.Tests/UnitTests/Workflows/IncidentWorkflowTests.cs
+++ b/TaskManagementSystem.Tests/UnitTests/Workflows/IncidentWorkflowTests.cs
@@ -1,0 +1,58 @@
+using TaskManagementSystem.DTOs.Request;
+using TaskManagementSystem.Enums;
+using TaskManagementSystem.Workflows;
+using Xunit;
+
+namespace TaskManagementSystem.Tests.UnitTests.Workflows;
+
+public sealed class IncidentWorkflowTests
+{
+    private readonly IncidentWorkflow _workflow = new();
+
+    [Fact]
+    public void Build_WhenDueDateNotProvided_UsesDefaults()
+    {
+        // Arrange
+        var dto = new CreateTaskRequestDto
+        {
+            Title = "Incident",
+            Description = "Service outage",
+            DueDate = default,
+            CategoryId = 10,
+            Kind = TaskKind.Incident
+        };
+
+        var before = DateTime.UtcNow;
+
+        // Act
+        var task = _workflow.Build(dto);
+
+        var after = DateTime.UtcNow;
+
+        // Assert
+        Assert.Equal(Priority.High, task.Priority);
+        Assert.Equal(Status.InProgress, task.Status);
+        Assert.False(task.IsCompleted);
+        Assert.InRange(task.DueDate, before.AddHours(4), after.AddHours(4));
+    }
+
+    [Fact]
+    public void Build_WhenDueDateProvided_UsesProvidedValue()
+    {
+        // Arrange
+        var dueDate = DateTime.UtcNow.AddHours(1);
+        var dto = new CreateTaskRequestDto
+        {
+            Title = "Incident",
+            DueDate = dueDate,
+            CategoryId = 3,
+            Kind = TaskKind.Incident
+        };
+
+        // Act
+        var task = _workflow.Build(dto);
+
+        // Assert
+        Assert.Equal(dueDate, task.DueDate);
+    }
+}

--- a/TaskManagementSystem/Builders/TaskEntityBuilder.cs
+++ b/TaskManagementSystem/Builders/TaskEntityBuilder.cs
@@ -1,0 +1,87 @@
+using TaskManagementSystem.Database.Models;
+using TaskManagementSystem.Enums;
+
+namespace TaskManagementSystem.Builders;
+
+public sealed class TaskEntityBuilder
+{
+    private readonly TaskEntity _taskEntity;
+
+    private TaskEntityBuilder(
+        string title,
+        string? description,
+        DateTime dueDate,
+        int categoryId,
+        TaskKind kind)
+    {
+        _taskEntity = new TaskEntity
+        {
+            Title = title,
+            Description = description,
+            DueDate = dueDate,
+            CategoryId = categoryId,
+            Kind = kind,
+            Priority = Priority.Medium,
+            Status = Status.Pending,
+            IsCompleted = false
+        };
+    }
+
+    public static TaskEntityBuilder Create(
+        string title,
+        string? description,
+        DateTime dueDate,
+        int categoryId,
+        TaskKind kind)
+    {
+        return new TaskEntityBuilder(title, description, dueDate, categoryId, kind);
+    }
+
+    public TaskEntityBuilder WithPriority(Priority priority)
+    {
+        _taskEntity.Priority = priority;
+        return this;
+    }
+
+    public TaskEntityBuilder WithStatus(Status status)
+    {
+        _taskEntity.Status = status;
+        _taskEntity.IsCompleted = status is Status.Completed or Status.Archived;
+        return this;
+    }
+
+    public TaskEntityBuilder WithStoryPoints(int? storyPoints)
+    {
+        _taskEntity.StoryPoints = storyPoints;
+        return this;
+    }
+
+    public TaskEntityBuilder WithDueDate(DateTime dueDate)
+    {
+        _taskEntity.DueDate = dueDate;
+        return this;
+    }
+
+    public TaskEntityBuilder WithKind(TaskKind kind)
+    {
+        _taskEntity.Kind = kind;
+        return this;
+    }
+
+    public TaskEntityBuilder WithCategory(int categoryId)
+    {
+        _taskEntity.CategoryId = categoryId;
+        return this;
+    }
+
+    public TaskEntityBuilder WithCompletionStatus(bool isCompleted)
+    {
+        _taskEntity.IsCompleted = isCompleted;
+        return this;
+    }
+
+    public TaskEntity Build()
+    {
+        return _taskEntity;
+    }
+}

--- a/TaskManagementSystem/Extensions/EntityMappingExtensions.cs
+++ b/TaskManagementSystem/Extensions/EntityMappingExtensions.cs
@@ -1,4 +1,5 @@
-﻿using TaskManagementSystem.Database.Models;
+using TaskManagementSystem.Builders;
+using TaskManagementSystem.Database.Models;
 using TaskManagementSystem.DTOs.Request;
 using TaskManagementSystem.Enums;
 
@@ -23,24 +24,20 @@ public static class EntityMappingExtensions
 
     public static TaskEntity ToTaskEntityForCreate(this CreateTaskRequestDto taskDto)
     {
-        var taskEntity = new TaskEntity()
-        {
-            Title = taskDto.Title,
-            Description = taskDto.Description,
-            DueDate = taskDto.DueDate,
-            IsCompleted = false,
-            Status = Status.Pending,
-            CategoryId = taskDto.CategoryId,
-            Kind = taskDto.Kind
-        };
+        var builder = TaskEntityBuilder.Create(
+            taskDto.Title,
+            taskDto.Description,
+            taskDto.DueDate,
+            taskDto.CategoryId,
+            taskDto.Kind);
 
         if (taskDto.Priority.HasValue)
-            taskEntity.Priority = taskDto.Priority.Value;
+            builder.WithPriority(taskDto.Priority.Value);
 
         if (taskDto.StoryPoints.HasValue)
-            taskEntity.StoryPoints = taskDto.StoryPoints.Value;
+            builder.WithStoryPoints(taskDto.StoryPoints.Value);
 
-        return taskEntity;
+        return builder.Build();
     }
 
     public static void UpdateTaskEntity(this UpdateTaskRequestDto taskDto, TaskEntity currentTask)

--- a/TaskManagementSystem/Workflows/BugWorkflow.cs
+++ b/TaskManagementSystem/Workflows/BugWorkflow.cs
@@ -1,3 +1,4 @@
+using TaskManagementSystem.Builders;
 using TaskManagementSystem.DTOs.Request;
 using TaskManagementSystem.Database.Models;
 using TaskManagementSystem.Enums;
@@ -17,16 +18,13 @@ public sealed class BugWorkflow : ITaskWorkflow
         var priority = dto.Severity >= 4 ? Priority.High : Priority.Low;
         var dueDate = dto.DueDate != default ? dto.DueDate : DateTime.UtcNow.AddDays(2);
 
-        return new TaskEntity
-        {
-            Title = dto.Title,
-            Description = dto.Description,
-            DueDate = dueDate,
-            Priority = priority,
-            IsCompleted = false,
-            Status = Status.Pending,
-            CategoryId = dto.CategoryId,
-            Kind = TaskKind.Bug
-        };
+        return TaskEntityBuilder.Create(
+                dto.Title,
+                dto.Description,
+                dueDate,
+                dto.CategoryId,
+                TaskKind.Bug)
+            .WithPriority(priority)
+            .Build();
     }
 }

--- a/TaskManagementSystem/Workflows/FeatureWorkflow.cs
+++ b/TaskManagementSystem/Workflows/FeatureWorkflow.cs
@@ -1,3 +1,4 @@
+using TaskManagementSystem.Builders;
 using TaskManagementSystem.DTOs.Request;
 using TaskManagementSystem.Database.Models;
 using TaskManagementSystem.Enums;
@@ -17,17 +18,14 @@ public sealed class FeatureWorkflow : ITaskWorkflow
         var dueDate = dto.DueDate != default ? dto.DueDate : DateTime.UtcNow.AddDays(14);
         var priority = dto.Priority ?? Priority.Medium;
 
-        return new TaskEntity
-        {
-            Title = dto.Title,
-            Description = dto.Description,
-            DueDate = dueDate,
-            Priority = priority,
-            StoryPoints = dto.StoryPoints,
-            IsCompleted = false,
-            Status = Status.Pending,
-            CategoryId = dto.CategoryId,
-            Kind = TaskKind.Feature
-        };
+        return TaskEntityBuilder.Create(
+                dto.Title,
+                dto.Description,
+                dueDate,
+                dto.CategoryId,
+                TaskKind.Feature)
+            .WithPriority(priority)
+            .WithStoryPoints(dto.StoryPoints!.Value)
+            .Build();
     }
 }

--- a/TaskManagementSystem/Workflows/IncidentWorkflow.cs
+++ b/TaskManagementSystem/Workflows/IncidentWorkflow.cs
@@ -1,3 +1,4 @@
+using TaskManagementSystem.Builders;
 using TaskManagementSystem.DTOs.Request;
 using TaskManagementSystem.Database.Models;
 using TaskManagementSystem.Enums;
@@ -12,16 +13,14 @@ public sealed class IncidentWorkflow : ITaskWorkflow
     {
         var dueDate = dto.DueDate != default ? dto.DueDate : DateTime.UtcNow.AddHours(4);
 
-        return new TaskEntity
-        {
-            Title = dto.Title,
-            Description = dto.Description,
-            DueDate = dueDate,
-            Priority = Priority.High,
-            IsCompleted = false,
-            Status = Status.InProgress,
-            CategoryId = dto.CategoryId,
-            Kind = TaskKind.Incident
-        };
+        return TaskEntityBuilder.Create(
+                dto.Title,
+                dto.Description,
+                dueDate,
+                dto.CategoryId,
+                TaskKind.Incident)
+            .WithPriority(Priority.High)
+            .WithStatus(Status.InProgress)
+            .Build();
     }
 }


### PR DESCRIPTION
## Summary
- add a TaskEntityBuilder to centralize TaskEntity initialization with chainable configuration helpers
- refactor task creation mapping and workflows to construct TaskEntity instances through the new builder
- add unit tests validating the builder behavior and workflow-specific defaults

## Testing
- dotnet test *(fails: `dotnet` CLI not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d266c76b9883328506eb342f83e3cb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing changes in this release.

- Refactor
  - Standardized task creation across workflows using a unified builder for consistent behavior and easier maintenance.

- Tests
  - Added extensive unit tests for task creation and workflows (Bug, Feature, Incident), validating priorities, statuses, due dates, completion flags, story points, and input validation.

- Chores
  - Internal adjustments to align code with the new builder approach without altering existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->