### PR TITLE
Add task cloning endpoint leveraging prototypes

### DIFF
--- a/TaskManagementSystem.Tests/UnitTests/Controllers/TasksControllerTests.cs
+++ b/TaskManagementSystem.Tests/UnitTests/Controllers/TasksControllerTests.cs
@@ -62,6 +62,39 @@ public sealed class TasksControllerTests
 
     #endregion
 
+    #region CloneTask
+
+    [Fact]
+    public async Task CloneTask_ReturnsOkResultWithClonedTask()
+    {
+        // Arrange
+        var taskId = 12;
+        var cloneRequest = new CloneTaskRequestDto
+        {
+            Title = "Copy"
+        };
+
+        var clonedTask = new TaskResponseDto
+        {
+            Id = 33,
+            Title = cloneRequest.Title
+        };
+
+        _tasksServiceMock.Setup(service => service.CloneTaskAsync(taskId, cloneRequest))
+            .ReturnsAsync(clonedTask);
+
+        // Act
+        var result = await _tasksController.CloneTask(taskId, cloneRequest);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.Equal(clonedTask, okResult.Value);
+
+        _tasksServiceMock.Verify(service => service.CloneTaskAsync(taskId, cloneRequest), Times.Once);
+    }
+
+    #endregion
+
     #region GetAllTasks
 
     [Fact]

--- a/TaskManagementSystem.Tests/UnitTests/LoggingDecorators/TasksServiceLoggingDecoratorTests.cs
+++ b/TaskManagementSystem.Tests/UnitTests/LoggingDecorators/TasksServiceLoggingDecoratorTests.cs
@@ -70,6 +70,40 @@ public sealed class TasksServiceLoggingDecoratorTests
 
     #endregion
 
+    #region CloneTask
+
+    [Fact]
+    public async Task CloneTaskAsync_LogsCloneInformation_ReturnsClonedTask()
+    {
+        // Arrange
+        var sourceTaskId = 12;
+        var cloneRequest = new CloneTaskRequestDto
+        {
+            Title = "Cloned task"
+        };
+
+        var clonedTask = new TaskResponseDto
+        {
+            Id = 42,
+            CategoryId = 4
+        };
+
+        _tasksServiceMock.Setup(service => service.CloneTaskAsync(sourceTaskId, cloneRequest))
+            .ReturnsAsync(clonedTask);
+
+        // Act
+        var result = await _tasksServiceLoggingDecorator.CloneTaskAsync(sourceTaskId, cloneRequest);
+
+        // Assert
+        Assert.Equal(clonedTask, result);
+        _tasksServiceMock.Verify(service => service.CloneTaskAsync(sourceTaskId, cloneRequest), Times.Once);
+
+        var message = string.Format(LoggingMessageConstants.TaskClonedSuccessfully, clonedTask.Id, sourceTaskId);
+        _loggerMock.VerifyLogInformationMessage(message);
+    }
+
+    #endregion
+
     #region GetAllTasks
 
     [Fact]

--- a/TaskManagementSystem.Tests/UnitTests/Prototypes/BugTaskPrototypeTests.cs
+++ b/TaskManagementSystem.Tests/UnitTests/Prototypes/BugTaskPrototypeTests.cs
@@ -1,0 +1,75 @@
+using TaskManagementSystem.Database.Models;
+using TaskManagementSystem.DTOs.Request;
+using TaskManagementSystem.Enums;
+using TaskManagementSystem.Workflows.Prototypes;
+using Xunit;
+
+namespace TaskManagementSystem.Tests.UnitTests.Prototypes;
+
+public sealed class BugTaskPrototypeTests
+{
+    private readonly BugTaskPrototype _prototype = new();
+
+    [Fact]
+    public void Clone_WithoutOverrides_KeepsSourceDetailsAndAssignsDefaultDueDate()
+    {
+        // Arrange
+        var sourceTask = new TaskEntity
+        {
+            Title = "Bug",
+            Description = "Bug desc",
+            DueDate = DateTime.UtcNow.AddDays(-1),
+            Priority = Priority.Low,
+            Status = Status.Completed,
+            IsCompleted = true,
+            CategoryId = 8,
+            Kind = TaskKind.Bug
+        };
+
+        var before = DateTime.UtcNow;
+
+        // Act
+        var clone = _prototype.Clone(sourceTask);
+
+        var after = DateTime.UtcNow;
+
+        // Assert
+        Assert.Equal(sourceTask.Title, clone.Title);
+        Assert.Equal(sourceTask.Description, clone.Description);
+        Assert.Equal(sourceTask.CategoryId, clone.CategoryId);
+        Assert.Equal(sourceTask.Priority, clone.Priority);
+        Assert.Equal(Status.Pending, clone.Status);
+        Assert.False(clone.IsCompleted);
+        Assert.Null(clone.StoryPoints);
+        Assert.InRange(clone.DueDate, before.AddDays(2), after.AddDays(2));
+    }
+
+    [Fact]
+    public void Clone_WithSeverity_AdjustsPriority()
+    {
+        // Arrange
+        var sourceTask = new TaskEntity
+        {
+            Title = "Bug",
+            Description = "Bug desc",
+            DueDate = DateTime.UtcNow,
+            Priority = Priority.Low,
+            Status = Status.Pending,
+            CategoryId = 2,
+            Kind = TaskKind.Bug
+        };
+
+        var request = new CloneTaskRequestDto
+        {
+            Severity = 5
+        };
+
+        // Act
+        var clone = _prototype.Clone(sourceTask, request);
+
+        // Assert
+        Assert.Equal(Priority.High, clone.Priority);
+        Assert.Equal(Status.Pending, clone.Status);
+        Assert.Null(clone.StoryPoints);
+    }
+}

--- a/TaskManagementSystem.Tests/UnitTests/Prototypes/FeatureTaskPrototypeTests.cs
+++ b/TaskManagementSystem.Tests/UnitTests/Prototypes/FeatureTaskPrototypeTests.cs
@@ -1,0 +1,90 @@
+using TaskManagementSystem.Database.Models;
+using TaskManagementSystem.DTOs.Request;
+using TaskManagementSystem.Enums;
+using TaskManagementSystem.Workflows.Prototypes;
+using Xunit;
+
+namespace TaskManagementSystem.Tests.UnitTests.Prototypes;
+
+public sealed class FeatureTaskPrototypeTests
+{
+    private readonly FeatureTaskPrototype _prototype = new();
+
+    [Fact]
+    public void Clone_WithoutOverrides_UsesSourceDetailsAndResetsDefaults()
+    {
+        // Arrange
+        var sourceTask = new TaskEntity
+        {
+            Title = "Feature",
+            Description = "Implement", 
+            DueDate = DateTime.UtcNow.AddDays(-3),
+            Priority = Priority.High,
+            Status = Status.Completed,
+            IsCompleted = true,
+            CategoryId = 4,
+            Kind = TaskKind.Feature,
+            StoryPoints = 5
+        };
+
+        var before = DateTime.UtcNow;
+
+        // Act
+        var clone = _prototype.Clone(sourceTask);
+
+        var after = DateTime.UtcNow;
+
+        // Assert
+        Assert.Equal(sourceTask.Title, clone.Title);
+        Assert.Equal(sourceTask.Description, clone.Description);
+        Assert.Equal(sourceTask.CategoryId, clone.CategoryId);
+        Assert.Equal(sourceTask.Priority, clone.Priority);
+        Assert.Equal(Status.Pending, clone.Status);
+        Assert.False(clone.IsCompleted);
+        Assert.Equal(sourceTask.StoryPoints, clone.StoryPoints);
+        Assert.Equal(TaskKind.Feature, clone.Kind);
+        Assert.InRange(clone.DueDate, before.AddDays(14), after.AddDays(14));
+    }
+
+    [Fact]
+    public void Clone_WithOverrides_AppliesOverrides()
+    {
+        // Arrange
+        var sourceTask = new TaskEntity
+        {
+            Title = "Feature",
+            Description = "Implement",
+            DueDate = DateTime.UtcNow,
+            Priority = Priority.Medium,
+            Status = Status.Pending,
+            IsCompleted = false,
+            CategoryId = 7,
+            Kind = TaskKind.Feature,
+            StoryPoints = 3
+        };
+
+        var request = new CloneTaskRequestDto
+        {
+            Title = "Feature copy",
+            Description = "Cloned",
+            DueDate = DateTime.UtcNow.AddDays(2),
+            CategoryId = 11,
+            Priority = Priority.Low,
+            Status = Status.Completed,
+            StoryPoints = 13
+        };
+
+        // Act
+        var clone = _prototype.Clone(sourceTask, request);
+
+        // Assert
+        Assert.Equal(request.Title, clone.Title);
+        Assert.Equal(request.Description, clone.Description);
+        Assert.Equal(request.CategoryId, clone.CategoryId);
+        Assert.Equal(request.Priority, clone.Priority);
+        Assert.Equal(request.Status, clone.Status);
+        Assert.True(clone.IsCompleted);
+        Assert.Equal(request.StoryPoints, clone.StoryPoints);
+        Assert.Equal(request.DueDate, clone.DueDate);
+    }
+}

--- a/TaskManagementSystem.Tests/UnitTests/Prototypes/IncidentTaskPrototypeTests.cs
+++ b/TaskManagementSystem.Tests/UnitTests/Prototypes/IncidentTaskPrototypeTests.cs
@@ -1,0 +1,79 @@
+using TaskManagementSystem.Database.Models;
+using TaskManagementSystem.DTOs.Request;
+using TaskManagementSystem.Enums;
+using TaskManagementSystem.Workflows.Prototypes;
+using Xunit;
+
+namespace TaskManagementSystem.Tests.UnitTests.Prototypes;
+
+public sealed class IncidentTaskPrototypeTests
+{
+    private readonly IncidentTaskPrototype _prototype = new();
+
+    [Fact]
+    public void Clone_WithoutOverrides_SetsIncidentDefaults()
+    {
+        // Arrange
+        var sourceTask = new TaskEntity
+        {
+            Title = "Incident",
+            Description = "Incident desc",
+            DueDate = DateTime.UtcNow.AddHours(-2),
+            Priority = Priority.Low,
+            Status = Status.Completed,
+            IsCompleted = true,
+            CategoryId = 9,
+            Kind = TaskKind.Incident
+        };
+
+        var before = DateTime.UtcNow;
+
+        // Act
+        var clone = _prototype.Clone(sourceTask);
+
+        var after = DateTime.UtcNow;
+
+        // Assert
+        Assert.Equal(sourceTask.Title, clone.Title);
+        Assert.Equal(sourceTask.Description, clone.Description);
+        Assert.Equal(sourceTask.CategoryId, clone.CategoryId);
+        Assert.Equal(Priority.High, clone.Priority);
+        Assert.Equal(Status.InProgress, clone.Status);
+        Assert.False(clone.IsCompleted);
+        Assert.Null(clone.StoryPoints);
+        Assert.InRange(clone.DueDate, before.AddHours(4), after.AddHours(4));
+    }
+
+    [Fact]
+    public void Clone_WithOverrides_AppliesOverrides()
+    {
+        // Arrange
+        var sourceTask = new TaskEntity
+        {
+            Title = "Incident",
+            Description = "Incident desc",
+            DueDate = DateTime.UtcNow,
+            Priority = Priority.High,
+            Status = Status.InProgress,
+            CategoryId = 1,
+            Kind = TaskKind.Incident
+        };
+
+        var request = new CloneTaskRequestDto
+        {
+            Priority = Priority.Low,
+            Status = Status.Pending,
+            DueDate = DateTime.UtcNow.AddHours(8),
+            CategoryId = 5
+        };
+
+        // Act
+        var clone = _prototype.Clone(sourceTask, request);
+
+        // Assert
+        Assert.Equal(request.Priority, clone.Priority);
+        Assert.Equal(request.Status, clone.Status);
+        Assert.Equal(request.DueDate, clone.DueDate);
+        Assert.Equal(request.CategoryId, clone.CategoryId);
+    }
+}

--- a/TaskManagementSystem/Constants/LoggingMessageConstants.cs
+++ b/TaskManagementSystem/Constants/LoggingMessageConstants.cs
@@ -3,6 +3,7 @@
 public static class LoggingMessageConstants
 {
     public const string TaskCreatedSuccessfully = "Task with Id {0} created successfully in CategoryId {1}.";
+    public const string TaskClonedSuccessfully = "Task with Id {0} cloned successfully from task {1}.";
     public const string TaskUpdatedSuccessfully = "Task with Id {0} updated successfully.";
     public const string TaskUnlockedSuccessfully = "Task with Id {0} unlocked successfully.";
     public const string TaskRemovedSuccessfully = "Task with Id {0} removed successfully.";

--- a/TaskManagementSystem/Constants/RouteConstants.cs
+++ b/TaskManagementSystem/Constants/RouteConstants.cs
@@ -14,5 +14,6 @@ public class RouteConstants
 
     public const string Tasks = $"{Api}/tasks";
     public const string TaskById = $"{Api}/tasks/{IdParamName}";
+    public const string TaskClone = $"{Api}/tasks/{IdParamName}/clone";
     public const string TaskBacklog = $"{Api}/tasks/backlog";
 }

--- a/TaskManagementSystem/Controllers/TasksController.cs
+++ b/TaskManagementSystem/Controllers/TasksController.cs
@@ -25,6 +25,15 @@ public class TasksController : ControllerBase
         return Ok(result);
     }
 
+    [HttpPost]
+    [Route(RouteConstants.TaskClone)]
+    public async Task<ActionResult<TaskResponseDto>> CloneTask([FromRoute] int id, [FromBody] CloneTaskRequestDto? cloneDto)
+    {
+        var result = await _tasksService.CloneTaskAsync(id, cloneDto);
+
+        return Ok(result);
+    }
+
     [HttpGet]
     [Route(RouteConstants.Tasks)]
     public async Task<ActionResult<IEnumerable<TaskResponseDto>>> GetAllTasks([FromQuery] GetAllTasksRequestDto sortBy)

--- a/TaskManagementSystem/DTOs/Request/CloneTaskRequestDto.cs
+++ b/TaskManagementSystem/DTOs/Request/CloneTaskRequestDto.cs
@@ -1,0 +1,22 @@
+using TaskManagementSystem.Enums;
+
+namespace TaskManagementSystem.DTOs.Request;
+
+public sealed class CloneTaskRequestDto
+{
+    public string? Title { get; set; }
+
+    public string? Description { get; set; }
+
+    public DateTime? DueDate { get; set; }
+
+    public int? CategoryId { get; set; }
+
+    public Priority? Priority { get; set; }
+
+    public Status? Status { get; set; }
+
+    public int? StoryPoints { get; set; }
+
+    public int? Severity { get; set; }
+}

--- a/TaskManagementSystem/Factories/ScrumTaskArtifactsFactory.cs
+++ b/TaskManagementSystem/Factories/ScrumTaskArtifactsFactory.cs
@@ -2,6 +2,7 @@ using TaskManagementSystem.BacklogOrderings;
 using TaskManagementSystem.Enums;
 using TaskManagementSystem.Interfaces;
 using TaskManagementSystem.Workflows;
+using TaskManagementSystem.Workflows.Prototypes;
 
 namespace TaskManagementSystem.Factories;
 
@@ -23,5 +24,14 @@ public sealed class ScrumTaskArtifactsFactory : ITaskArtifactsFactory
         TaskKind.Incident => new IncidentBacklogOrdering(),
         TaskKind.Research => new FeatureBacklogOrdering(),
         _ => new DefaultBacklogOrdering()
+    };
+
+    public ITaskPrototype CreatePrototype(TaskKind kind) => kind switch
+    {
+        TaskKind.Bug => new BugTaskPrototype(),
+        TaskKind.Feature => new FeatureTaskPrototype(),
+        TaskKind.Incident => new IncidentTaskPrototype(),
+        TaskKind.Research => new FeatureTaskPrototype(),
+        _ => new FeatureTaskPrototype()
     };
 }

--- a/TaskManagementSystem/Interfaces/Factories/ITaskArtifactsFactory.cs
+++ b/TaskManagementSystem/Interfaces/Factories/ITaskArtifactsFactory.cs
@@ -1,5 +1,6 @@
 using TaskManagementSystem.Enums;
 using TaskManagementSystem.Workflows;
+using TaskManagementSystem.Workflows.Prototypes;
 
 namespace TaskManagementSystem.Interfaces;
 
@@ -8,4 +9,6 @@ public interface ITaskArtifactsFactory
     ITaskWorkflow CreateWorkflow(TaskKind kind);
 
     IBacklogOrdering CreateBacklogOrdering(TaskKind kind);
+
+    ITaskPrototype CreatePrototype(TaskKind kind);
 }

--- a/TaskManagementSystem/Interfaces/Services/ITasksService.cs
+++ b/TaskManagementSystem/Interfaces/Services/ITasksService.cs
@@ -8,6 +8,8 @@ public interface ITasksService
 {
     Task<TaskResponseDto> CreateTaskAsync(CreateTaskRequestDto taskDto);
 
+    Task<TaskResponseDto> CloneTaskAsync(int taskId, CloneTaskRequestDto? cloneDto);
+
     Task<IEnumerable<TaskResponseDto>> GetAllTasksAsync(GetAllTasksRequestDto sortBy);
 
     Task<IEnumerable<TaskResponseDto>> GetBacklogAsync(TaskKind kind);

--- a/TaskManagementSystem/LoggingDecorators/TasksServiceLoggingDecorator.cs
+++ b/TaskManagementSystem/LoggingDecorators/TasksServiceLoggingDecorator.cs
@@ -28,6 +28,15 @@ public class TasksServiceLoggingDecorator : ITasksService
         return task;
     }
 
+    public async Task<TaskResponseDto> CloneTaskAsync(int taskId, CloneTaskRequestDto? cloneDto)
+    {
+        var clonedTask = await _wrappee.CloneTaskAsync(taskId, cloneDto);
+
+        _logger.LogInformation(LoggingMessageConstants.TaskClonedSuccessfully, clonedTask.Id, taskId);
+
+        return clonedTask;
+    }
+
     public async Task<IEnumerable<TaskResponseDto>> GetAllTasksAsync(GetAllTasksRequestDto sortBy)
     {
         return await _wrappee.GetAllTasksAsync(sortBy);

--- a/TaskManagementSystem/Workflows/Prototypes/BugTaskPrototype.cs
+++ b/TaskManagementSystem/Workflows/Prototypes/BugTaskPrototype.cs
@@ -1,0 +1,44 @@
+using TaskManagementSystem.Builders;
+using TaskManagementSystem.Database.Models;
+using TaskManagementSystem.DTOs.Request;
+using TaskManagementSystem.Enums;
+
+namespace TaskManagementSystem.Workflows.Prototypes;
+
+public sealed class BugTaskPrototype : TaskPrototypeBase
+{
+    public BugTaskPrototype()
+        : base(new TaskEntity
+        {
+            Kind = TaskKind.Bug,
+            Priority = Priority.Low,
+            Status = Status.Pending,
+            IsCompleted = false
+        })
+    {
+    }
+
+    protected override DateTime GetDefaultDueDate(TaskEntity sourceTask)
+    {
+        return DateTime.UtcNow.AddDays(2);
+    }
+
+    protected override Priority GetPriority(TaskEntity sourceTask, CloneTaskRequestDto cloneRequest)
+    {
+        if (cloneRequest.Priority.HasValue)
+            return cloneRequest.Priority.Value;
+
+        if (cloneRequest.Severity.HasValue)
+            return cloneRequest.Severity.Value >= 4 ? Priority.High : Priority.Low;
+
+        return sourceTask.Priority;
+    }
+
+    protected override TaskEntityBuilder Configure(
+        TaskEntityBuilder builder,
+        TaskEntity sourceTask,
+        CloneTaskRequestDto cloneRequest)
+    {
+        return builder.WithStoryPoints(null);
+    }
+}

--- a/TaskManagementSystem/Workflows/Prototypes/FeatureTaskPrototype.cs
+++ b/TaskManagementSystem/Workflows/Prototypes/FeatureTaskPrototype.cs
@@ -1,0 +1,43 @@
+using TaskManagementSystem.Builders;
+using TaskManagementSystem.Database.Models;
+using TaskManagementSystem.DTOs.Request;
+using TaskManagementSystem.Enums;
+
+namespace TaskManagementSystem.Workflows.Prototypes;
+
+public sealed class FeatureTaskPrototype : TaskPrototypeBase
+{
+    public FeatureTaskPrototype()
+        : base(new TaskEntity
+        {
+            Kind = TaskKind.Feature,
+            Priority = Priority.Medium,
+            Status = Status.Pending,
+            IsCompleted = false
+        })
+    {
+    }
+
+    protected override DateTime GetDefaultDueDate(TaskEntity sourceTask)
+    {
+        return DateTime.UtcNow.AddDays(14);
+    }
+
+    protected override Priority GetPriority(TaskEntity sourceTask, CloneTaskRequestDto cloneRequest)
+    {
+        return cloneRequest.Priority ?? sourceTask.Priority;
+    }
+
+    protected override TaskEntityBuilder Configure(
+        TaskEntityBuilder builder,
+        TaskEntity sourceTask,
+        CloneTaskRequestDto cloneRequest)
+    {
+        var storyPoints = cloneRequest.StoryPoints ?? sourceTask.StoryPoints;
+
+        if (!storyPoints.HasValue)
+            throw new InvalidOperationException("Feature requires StoryPoints to clone.");
+
+        return builder.WithStoryPoints(storyPoints.Value);
+    }
+}

--- a/TaskManagementSystem/Workflows/Prototypes/ITaskPrototype.cs
+++ b/TaskManagementSystem/Workflows/Prototypes/ITaskPrototype.cs
@@ -1,0 +1,9 @@
+using TaskManagementSystem.Database.Models;
+using TaskManagementSystem.DTOs.Request;
+
+namespace TaskManagementSystem.Workflows.Prototypes;
+
+public interface ITaskPrototype
+{
+    TaskEntity Clone(TaskEntity sourceTask, CloneTaskRequestDto? cloneRequest = null);
+}

--- a/TaskManagementSystem/Workflows/Prototypes/IncidentTaskPrototype.cs
+++ b/TaskManagementSystem/Workflows/Prototypes/IncidentTaskPrototype.cs
@@ -1,0 +1,38 @@
+using TaskManagementSystem.Builders;
+using TaskManagementSystem.Database.Models;
+using TaskManagementSystem.DTOs.Request;
+using TaskManagementSystem.Enums;
+
+namespace TaskManagementSystem.Workflows.Prototypes;
+
+public sealed class IncidentTaskPrototype : TaskPrototypeBase
+{
+    public IncidentTaskPrototype()
+        : base(new TaskEntity
+        {
+            Kind = TaskKind.Incident,
+            Priority = Priority.High,
+            Status = Status.InProgress,
+            IsCompleted = false
+        })
+    {
+    }
+
+    protected override DateTime GetDefaultDueDate(TaskEntity sourceTask)
+    {
+        return DateTime.UtcNow.AddHours(4);
+    }
+
+    protected override Priority GetPriority(TaskEntity sourceTask, CloneTaskRequestDto cloneRequest)
+    {
+        return cloneRequest.Priority ?? Priority.High;
+    }
+
+    protected override TaskEntityBuilder Configure(
+        TaskEntityBuilder builder,
+        TaskEntity sourceTask,
+        CloneTaskRequestDto cloneRequest)
+    {
+        return builder.WithStoryPoints(null);
+    }
+}

--- a/TaskManagementSystem/Workflows/Prototypes/TaskPrototypeBase.cs
+++ b/TaskManagementSystem/Workflows/Prototypes/TaskPrototypeBase.cs
@@ -1,0 +1,57 @@
+using TaskManagementSystem.Builders;
+using TaskManagementSystem.Database.Models;
+using TaskManagementSystem.DTOs.Request;
+using TaskManagementSystem.Enums;
+
+namespace TaskManagementSystem.Workflows.Prototypes;
+
+public abstract class TaskPrototypeBase : ITaskPrototype
+{
+    protected TaskPrototypeBase(TaskEntity prototype)
+    {
+        Prototype = prototype;
+    }
+
+    protected TaskEntity Prototype { get; }
+
+    public TaskEntity Clone(TaskEntity sourceTask, CloneTaskRequestDto? cloneRequest = null)
+    {
+        if (sourceTask is null)
+            throw new ArgumentNullException(nameof(sourceTask));
+
+        cloneRequest ??= new CloneTaskRequestDto();
+
+        var title = string.IsNullOrWhiteSpace(cloneRequest.Title)
+            ? sourceTask.Title
+            : cloneRequest.Title!;
+
+        var description = cloneRequest.Description ?? sourceTask.Description;
+        var dueDate = cloneRequest.DueDate ?? GetDefaultDueDate(sourceTask);
+        var categoryId = cloneRequest.CategoryId ?? sourceTask.CategoryId;
+        var priority = GetPriority(sourceTask, cloneRequest);
+        var status = cloneRequest.Status ?? Prototype.Status;
+
+        var builder = TaskEntityBuilder.Create(
+                title,
+                description,
+                dueDate,
+                categoryId,
+                sourceTask.Kind)
+            .WithPriority(priority)
+            .WithStatus(status);
+
+        return Configure(builder, sourceTask, cloneRequest).Build();
+    }
+
+    protected virtual DateTime GetDefaultDueDate(TaskEntity sourceTask) => sourceTask.DueDate;
+
+    protected virtual Priority GetPriority(TaskEntity sourceTask, CloneTaskRequestDto cloneRequest)
+    {
+        return cloneRequest.Priority ?? Prototype.Priority;
+    }
+
+    protected abstract TaskEntityBuilder Configure(
+        TaskEntityBuilder builder,
+        TaskEntity sourceTask,
+        CloneTaskRequestDto cloneRequest);
+}


### PR DESCRIPTION
## Summary
- add a clone task request DTO and REST endpoint to expose prototype-based cloning from the API
- update services, factories, and logging to clone tasks through reusable prototypes built on the TaskEntityBuilder
- restore builder-centric workflows and cover the new cloning flow and prototype behavior with unit and integration tests

## Testing
- `dotnet test TaskManagementSystem.sln` *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d28517d0c48332be6c908b0008b2dd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added task cloning via a new endpoint. Supports optional overrides (title, description, due date, category, priority, status, story points, severity). Applies smart defaults per task type: Feature (keeps story points, Pending, ~+14 days), Bug (priority may increase by severity, clears story points, ~+2 days), Incident (High priority, In Progress, ~+4 hours). Returns the cloned task.
- Logging
  - Added a success log message when a task is cloned.
- Tests
  - Added comprehensive unit and integration tests for cloning across controller, service, logging, and prototypes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->