### PR TITLE
Cache scrum task artifacts and register singleton

### DIFF
--- a/TaskManagementSystem/Extensions/DependencyInjectionExtensions.cs
+++ b/TaskManagementSystem/Extensions/DependencyInjectionExtensions.cs
@@ -35,7 +35,7 @@ public static class DependencyInjectionExtensions
         services.AddScoped<ITasksService, ScrumTasksService>();
         services.Decorate<ITasksService, TasksServiceLoggingDecorator>();
 
-        services.AddScoped<ITaskArtifactsFactory, ScrumTaskArtifactsFactory>();
+        services.AddSingleton<ITaskArtifactsFactory, ScrumTaskArtifactsFactory>();
 
         services.AddScoped<ICategoriesService, CategoriesSerivce>();
         services.Decorate<ICategoriesService, CategoriesServiceLoggingDecorator>();

--- a/TaskManagementSystem/Factories/ScrumTaskArtifactsFactory.cs
+++ b/TaskManagementSystem/Factories/ScrumTaskArtifactsFactory.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
 using TaskManagementSystem.BacklogOrderings;
 using TaskManagementSystem.Enums;
 using TaskManagementSystem.Interfaces;
@@ -7,21 +10,46 @@ namespace TaskManagementSystem.Factories;
 
 public sealed class ScrumTaskArtifactsFactory : ITaskArtifactsFactory
 {
-    public ITaskWorkflow CreateWorkflow(TaskKind kind) => kind switch
+    private static readonly Lazy<ITaskWorkflow> BugWorkflow = new(() => new BugWorkflow(), LazyThreadSafetyMode.ExecutionAndPublication);
+    private static readonly Lazy<ITaskWorkflow> FeatureWorkflow = new(() => new FeatureWorkflow(), LazyThreadSafetyMode.ExecutionAndPublication);
+    private static readonly Lazy<ITaskWorkflow> IncidentWorkflow = new(() => new IncidentWorkflow(), LazyThreadSafetyMode.ExecutionAndPublication);
+    private static readonly IReadOnlyDictionary<TaskKind, Lazy<ITaskWorkflow>> Workflows = new Dictionary<TaskKind, Lazy<ITaskWorkflow>>
     {
-        TaskKind.Bug => new BugWorkflow(),
-        TaskKind.Feature => new FeatureWorkflow(),
-        TaskKind.Incident => new IncidentWorkflow(),
-        TaskKind.Research => new FeatureWorkflow(),
-        _ => new FeatureWorkflow()
+        [TaskKind.Bug] = BugWorkflow,
+        [TaskKind.Feature] = FeatureWorkflow,
+        [TaskKind.Incident] = IncidentWorkflow,
+        [TaskKind.Research] = FeatureWorkflow
     };
 
-    public IBacklogOrdering CreateBacklogOrdering(TaskKind kind) => kind switch
+    private static readonly Lazy<IBacklogOrdering> BugBacklogOrdering = new(() => new BugBacklogOrdering(), LazyThreadSafetyMode.ExecutionAndPublication);
+    private static readonly Lazy<IBacklogOrdering> FeatureBacklogOrdering = new(() => new FeatureBacklogOrdering(), LazyThreadSafetyMode.ExecutionAndPublication);
+    private static readonly Lazy<IBacklogOrdering> IncidentBacklogOrdering = new(() => new IncidentBacklogOrdering(), LazyThreadSafetyMode.ExecutionAndPublication);
+    private static readonly Lazy<IBacklogOrdering> DefaultBacklogOrdering = new(() => new DefaultBacklogOrdering(), LazyThreadSafetyMode.ExecutionAndPublication);
+    private static readonly IReadOnlyDictionary<TaskKind, Lazy<IBacklogOrdering>> BacklogOrderings = new Dictionary<TaskKind, Lazy<IBacklogOrdering>>
     {
-        TaskKind.Bug => new BugBacklogOrdering(),
-        TaskKind.Feature => new FeatureBacklogOrdering(),
-        TaskKind.Incident => new IncidentBacklogOrdering(),
-        TaskKind.Research => new FeatureBacklogOrdering(),
-        _ => new DefaultBacklogOrdering()
+        [TaskKind.Bug] = BugBacklogOrdering,
+        [TaskKind.Feature] = FeatureBacklogOrdering,
+        [TaskKind.Incident] = IncidentBacklogOrdering,
+        [TaskKind.Research] = FeatureBacklogOrdering
     };
+
+    public ITaskWorkflow CreateWorkflow(TaskKind kind)
+    {
+        if (Workflows.TryGetValue(kind, out var workflow))
+        {
+            return workflow.Value;
+        }
+
+        return FeatureWorkflow.Value;
+    }
+
+    public IBacklogOrdering CreateBacklogOrdering(TaskKind kind)
+    {
+        if (BacklogOrderings.TryGetValue(kind, out var backlogOrdering))
+        {
+            return backlogOrdering.Value;
+        }
+
+        return DefaultBacklogOrdering.Value;
+    }
 }


### PR DESCRIPTION
## Summary
- cache Scrum workflows and backlog ordering instances with Lazy dictionaries keyed by task kind
- reuse the ScrumTaskArtifactsFactory across the app by registering it as a singleton

## Testing
- `dotnet test` *(fails: `dotnet` command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2cf0d42ec83328c2eb74cf87522d6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Performance Improvements
  - Faster, more responsive task operations through caching and reusing workflow and backlog ordering components.
  - Reduced overhead from repeated initialization, improving performance during repeated actions.

- Reliability
  - More consistent behavior across requests due to unified instance management, resulting in predictable task workflow and backlog ordering outcomes.

- Refactor
  - Internal optimizations to streamline how task workflows and backlog orderings are resolved, without changing public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->