### PR TITLE
Refactor report filtering into reusable query builder

### DIFF
--- a/TaskManagementSystem.Tests/UnitTests/Services/ReportTasksQueryBuilderTests.cs
+++ b/TaskManagementSystem.Tests/UnitTests/Services/ReportTasksQueryBuilderTests.cs
@@ -1,0 +1,126 @@
+using System.Collections.Generic;
+using System.Linq;
+using TaskManagementSystem.Database.Models;
+using TaskManagementSystem.DTOs.Request;
+using TaskManagementSystem.Enums;
+using TaskManagementSystem.Reports;
+
+namespace TaskManagementSystem.Tests.UnitTests.Services;
+
+public sealed class ReportTasksQueryBuilderTests
+{
+    private static readonly List<TaskEntity> TaskSource =
+    [
+        new()
+        {
+            Id = 1,
+            Title = "Todo task",
+            CategoryId = 1,
+            Status = Status.Todo,
+            Priority = Priority.Low,
+            DueDate = new DateTime(2024, 1, 10, 0, 0, 0, DateTimeKind.Utc),
+            Category = null!
+        },
+        new()
+        {
+            Id = 2,
+            Title = "In progress task",
+            CategoryId = 1,
+            Status = Status.InProgress,
+            Priority = Priority.High,
+            DueDate = new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Utc),
+            Category = null!
+        },
+        new()
+        {
+            Id = 3,
+            Title = "Completed task",
+            CategoryId = 2,
+            Status = Status.Completed,
+            Priority = Priority.Medium,
+            DueDate = new DateTime(2024, 1, 20, 0, 0, 0, DateTimeKind.Utc),
+            Category = null!
+        }
+    ];
+
+    private readonly ReportTasksQueryBuilder _sut = new();
+
+    [Fact]
+    public void Apply_WithStatusFilter_ReturnsOnlyMatchingTasks()
+    {
+        var filters = new ReportTasksRequestDto { Status = Status.InProgress };
+
+        var result = _sut.Apply(CreateSource(), filters).Select(task => task.Id).ToArray();
+
+        Assert.Equal(new[] { 2 }, result);
+    }
+
+    [Fact]
+    public void Apply_WithPriorityFilter_ReturnsOnlyMatchingTasks()
+    {
+        var filters = new ReportTasksRequestDto { Priority = Priority.High };
+
+        var result = _sut.Apply(CreateSource(), filters).Select(task => task.Id).ToArray();
+
+        Assert.Equal(new[] { 2 }, result);
+    }
+
+    [Fact]
+    public void Apply_WithDueAfterFilter_ReturnsTasksAfterProvidedDate()
+    {
+        var filters = new ReportTasksRequestDto
+        {
+            DueAfter = new DateTime(2024, 1, 12, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        var result = _sut.Apply(CreateSource(), filters).Select(task => task.Id).ToArray();
+
+        Assert.Equal(new[] { 2, 3 }, result);
+    }
+
+    [Fact]
+    public void Apply_WithDueBeforeFilter_ReturnsTasksBeforeProvidedDate()
+    {
+        var filters = new ReportTasksRequestDto
+        {
+            DueBefore = new DateTime(2024, 1, 18, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        var result = _sut.Apply(CreateSource(), filters).Select(task => task.Id).ToArray();
+
+        Assert.Equal(new[] { 1, 2 }, result);
+    }
+
+    [Fact]
+    public void Apply_WithCombinedDueDateFilters_ReturnsTasksWithinRange()
+    {
+        var filters = new ReportTasksRequestDto
+        {
+            DueAfter = new DateTime(2024, 1, 12, 0, 0, 0, DateTimeKind.Utc),
+            DueBefore = new DateTime(2024, 1, 18, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        var result = _sut.Apply(CreateSource(), filters).Select(task => task.Id).ToArray();
+
+        Assert.Equal(new[] { 2 }, result);
+    }
+
+    [Fact]
+    public void Apply_WhenInvokedMultipleTimes_RemainsStateless()
+    {
+        var highPriorityFilters = new ReportTasksRequestDto { Priority = Priority.High };
+        var completedStatusFilters = new ReportTasksRequestDto { Status = Status.Completed };
+
+        var firstCall = _sut.Apply(CreateSource(), highPriorityFilters).Select(task => task.Id).ToArray();
+        var secondCall = _sut.Apply(CreateSource(), highPriorityFilters).Select(task => task.Id).ToArray();
+        var thirdCall = _sut.Apply(CreateSource(), completedStatusFilters).Select(task => task.Id).ToArray();
+
+        Assert.Equal(firstCall, secondCall);
+        Assert.Equal(new[] { 3 }, thirdCall);
+    }
+
+    private static IQueryable<TaskEntity> CreateSource()
+    {
+        return TaskSource.AsQueryable();
+    }
+}

--- a/TaskManagementSystem/Extensions/DependencyInjectionExtensions.cs
+++ b/TaskManagementSystem/Extensions/DependencyInjectionExtensions.cs
@@ -2,12 +2,14 @@
 using TaskManagementSystem.Database;
 using TaskManagementSystem.ExceptionHandlers;
 using TaskManagementSystem.Exceptions;
-using TaskManagementSystem.TaskDeleteStategy;
 using TaskManagementSystem.Interfaces;
+using TaskManagementSystem.Interfaces.Reports;
 using TaskManagementSystem.LoggingDecorators;
 using TaskManagementSystem.Checkers;
 using TaskManagementSystem.Services;
 using TaskManagementSystem.Factories;
+using TaskManagementSystem.Reports;
+using TaskManagementSystem.TaskDeleteStategy;
 
 namespace TaskManagementSystem.Extensions;
 
@@ -39,6 +41,8 @@ public static class DependencyInjectionExtensions
 
         services.AddScoped<ICategoriesService, CategoriesSerivce>();
         services.Decorate<ICategoriesService, CategoriesServiceLoggingDecorator>();
+
+        services.AddSingleton<IReportTasksQueryBuilder, ReportTasksQueryBuilder>();
 
         services.AddScoped<IReportsService, ReportsService>();
 

--- a/TaskManagementSystem/Interfaces/Reports/IReportTasksQueryBuilder.cs
+++ b/TaskManagementSystem/Interfaces/Reports/IReportTasksQueryBuilder.cs
@@ -1,0 +1,10 @@
+using System.Linq;
+using TaskManagementSystem.Database.Models;
+using TaskManagementSystem.DTOs.Request;
+
+namespace TaskManagementSystem.Interfaces.Reports;
+
+public interface IReportTasksQueryBuilder
+{
+    IQueryable<TaskEntity> Apply(IQueryable<TaskEntity> source, ReportTasksRequestDto filters);
+}

--- a/TaskManagementSystem/Reports/ReportTasksQueryBuilder.cs
+++ b/TaskManagementSystem/Reports/ReportTasksQueryBuilder.cs
@@ -1,0 +1,39 @@
+using System.Linq;
+using TaskManagementSystem.Database.Models;
+using TaskManagementSystem.DTOs.Request;
+using TaskManagementSystem.Interfaces.Reports;
+
+namespace TaskManagementSystem.Reports;
+
+public sealed class ReportTasksQueryBuilder : IReportTasksQueryBuilder
+{
+    public IQueryable<TaskEntity> Apply(IQueryable<TaskEntity> source, ReportTasksRequestDto filters)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(filters);
+
+        var query = source;
+
+        if (filters.Status.HasValue)
+        {
+            query = query.Where(task => task.Status == filters.Status);
+        }
+
+        if (filters.Priority.HasValue)
+        {
+            query = query.Where(task => task.Priority == filters.Priority);
+        }
+
+        if (filters.DueAfter.HasValue)
+        {
+            query = query.Where(task => task.DueDate > filters.DueAfter);
+        }
+
+        if (filters.DueBefore.HasValue)
+        {
+            query = query.Where(task => task.DueDate < filters.DueBefore);
+        }
+
+        return query;
+    }
+}

--- a/TaskManagementSystem/Services/ReportsService.cs
+++ b/TaskManagementSystem/Services/ReportsService.cs
@@ -5,21 +5,24 @@ using TaskManagementSystem.DTOs.Request;
 using TaskManagementSystem.DTOs.Response;
 using TaskManagementSystem.Helpers;
 using TaskManagementSystem.Interfaces;
+using TaskManagementSystem.Interfaces.Reports;
 
 namespace TaskManagementSystem.Services;
 
 public class ReportsService : IReportsService
 {
     private readonly TaskManagementSystemDbContext _dbContext;
+    private readonly IReportTasksQueryBuilder _reportTasksQueryBuilder;
 
-    public ReportsService(TaskManagementSystemDbContext dbContext)
+    public ReportsService(TaskManagementSystemDbContext dbContext, IReportTasksQueryBuilder reportTasksQueryBuilder)
     {
         _dbContext = dbContext;
+        _reportTasksQueryBuilder = reportTasksQueryBuilder;
     }
 
     public async Task<IEnumerable<ReportTasksResponseDto>> GetReportForTasksAsync(ReportTasksRequestDto reportFilters)
     {
-        IQueryable<TaskEntity> tasks = ApplyFilters(_dbContext.Tasks, reportFilters);
+        IQueryable<TaskEntity> tasks = _reportTasksQueryBuilder.Apply(_dbContext.Tasks, reportFilters);
 
         var result = await tasks
             .GroupBy(x => x.CategoryId)
@@ -34,28 +37,4 @@ public class ReportsService : IReportsService
         return result;
     }
 
-    private IQueryable<TaskEntity> ApplyFilters(IQueryable<TaskEntity> tasks, ReportTasksRequestDto reportDto)
-    {
-        if (reportDto.Status.HasValue)
-        {
-            tasks = tasks.Where(x => x.Status == reportDto.Status);
-        }
-
-        if (reportDto.Priority.HasValue)
-        {
-            tasks = tasks.Where(x => x.Priority == reportDto.Priority);
-        }
-
-        if (reportDto.DueAfter.HasValue)
-        {
-            tasks = tasks.Where(x => x.DueDate > reportDto.DueAfter);
-        }
-
-        if (reportDto.DueBefore.HasValue)
-        {
-            tasks = tasks.Where(x => x.DueDate < reportDto.DueBefore);
-        }
-
-        return tasks;
-    }
 }


### PR DESCRIPTION
## Summary
- extract the task report filtering into a dedicated `IReportTasksQueryBuilder` and implementation
- inject the builder into `ReportsService` and register it for dependency injection
- add unit tests that exercise each filter path and verify the builder remains stateless across calls

## Testing
- `dotnet test` *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e39212808332a0538de491a3242b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Centralized task report filtering to improve consistency and performance. Supports filtering by status, priority, and due date ranges. No UI changes.
- Tests
  - Added comprehensive unit tests for report filtering, covering status, priority, and due date (before/after and combined) to ensure reliable results across repeated runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->